### PR TITLE
Refactor types and codestyle

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0]
+        php: [7.4, '8.0', 8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, json, libxml, mbstring, zip, pcntl, bcmath, intl, exif, iconv, fileinfo
           coverage: none
 
       - name: Setup problem matchers

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,11 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "scrivo/highlight.php": "v9.18.1.9"
+        "php": "^7.4 || ^8.0",
+        "ext-dom": "*",
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "scrivo/highlight.php": "^9.18.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "scrivo/highlight.php": "^9.18.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.5",
         "pestphp/pest": "^1.21",
         "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "^4.3"
+        "vimeo/psalm": "^4.19"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +44,7 @@
         "test": "./vendor/bin/pest",
         "test-watch": "nodemon --exec './vendor/bin/pest || exit 1' --ext php",
         "test-coverage": "./vendor/bin/pest --coverage-html coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes --config=.php_cs.dist.php"
     },
     "config": {
         "sort-packages": true

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -12,6 +12,7 @@
         <ignoreFiles>
             <directory name="vendor"/>
             <file name="src/NewDOMSerializer.php" />
+            <file name="src/DOMSerializerPointer.php" />
         </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/Core/Extension.php
+++ b/src/Core/Extension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Core;
 

--- a/src/Core/Extension.php
+++ b/src/Core/Extension.php
@@ -2,7 +2,7 @@
 
 namespace Tiptap\Core;
 
-class Extension
+abstract class Extension
 {
     public static $name;
 

--- a/src/Core/Extension.php
+++ b/src/Core/Extension.php
@@ -4,19 +4,20 @@ namespace Tiptap\Core;
 
 abstract class Extension
 {
-    public static $name;
+    public static string $name;
+    public array $options = [];
 
     public function __construct(array $options = [])
     {
         $this->options = array_merge($this->addOptions(), $options);
     }
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [];
     }
 
-    public function addExtensions()
+    public function addExtensions(): array
     {
         return [];
     }

--- a/src/Core/Mark.php
+++ b/src/Core/Mark.php
@@ -12,7 +12,7 @@ abstract class Mark
         $this->options = array_merge($this->addOptions(), $options);
     }
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'HTMLAttributes' => [],

--- a/src/Core/Mark.php
+++ b/src/Core/Mark.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Core;
 

--- a/src/Core/Mark.php
+++ b/src/Core/Mark.php
@@ -19,6 +19,6 @@ abstract class Mark
         ];
     }
 
-    abstract public function renderHTML($mark): array;
+    abstract public function renderHTML($mark, array $HTMLAttributes = []): array;
     abstract public function parseHTML(): array;
 }

--- a/src/Core/Mark.php
+++ b/src/Core/Mark.php
@@ -2,9 +2,10 @@
 
 namespace Tiptap\Core;
 
-class Mark
+abstract class Mark
 {
     public static $name;
+    public array $options = [];
 
     public function __construct(array $options = [])
     {
@@ -13,16 +14,11 @@ class Mark
 
     public function addOptions()
     {
-        return [];
+        return [
+            'HTMLAttributes' => [],
+        ];
     }
 
-    public function renderHTML($mark)
-    {
-        return null;
-    }
-
-    public function parseHTML()
-    {
-        return [];
-    }
+    abstract public function renderHTML($mark): array;
+    abstract public function parseHTML(): array;
 }

--- a/src/Core/Mark.php
+++ b/src/Core/Mark.php
@@ -4,7 +4,7 @@ namespace Tiptap\Core;
 
 abstract class Mark
 {
-    public static $name;
+    public static string $name;
     public array $options = [];
 
     public function __construct(array $options = [])

--- a/src/Core/Mark.php
+++ b/src/Core/Mark.php
@@ -20,5 +20,6 @@ abstract class Mark
     }
 
     abstract public function renderHTML($mark, array $HTMLAttributes = []): array;
+
     abstract public function parseHTML(): array;
 }

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Core;
 

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -25,7 +25,7 @@ abstract class Node
         return [];
     }
 
-    public function renderHTML($node): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return null;
     }

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -2,33 +2,35 @@
 
 namespace Tiptap\Core;
 
-class Node
+abstract class Node
 {
     public static $name;
-
     public static $marks = '_';
+    public array $options = [];
 
     public function __construct(array $options = [])
     {
         $this->options = array_merge($this->addOptions(), $options);
     }
 
-    public function addOptions()
+     public function addOptions(): array
+     {
+         return [
+             'HTMLAttributes' => [],
+         ];
+     }
+
+    public function parseHTML(): array
     {
         return [];
     }
 
-    public function parseHTML()
-    {
-        return [];
-    }
-
-    public function renderHTML($node)
+    public function renderHTML($node): ?array
     {
         return null;
     }
 
-    public static function wrapper($DOMNode)
+    public static function wrapper($DOMNode): ?array
     {
         return null;
     }

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -13,12 +13,17 @@ abstract class Node
         $this->options = array_merge($this->addOptions(), $options);
     }
 
-     public function addOptions(): array
-     {
-         return [
-             'HTMLAttributes' => [],
-         ];
-     }
+    public function addOptions(): array
+    {
+        return [
+            'HTMLAttributes' => [],
+        ];
+    }
+
+    public static function wrapper($DOMNode): ?array
+    {
+        return null;
+    }
 
     public function parseHTML(): array
     {
@@ -26,11 +31,6 @@ abstract class Node
     }
 
     public function renderHTML($node, array $HTMLAttributes = []): ?array
-    {
-        return null;
-    }
-
-    public static function wrapper($DOMNode): ?array
     {
         return null;
     }

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -4,8 +4,8 @@ namespace Tiptap\Core;
 
 abstract class Node
 {
-    public static $name;
-    public static $marks = '_';
+    public static string $name;
+    public static string $marks = '_';
     public array $options = [];
 
     public function __construct(array $options = [])

--- a/src/DOMParser.php
+++ b/src/DOMParser.php
@@ -94,7 +94,7 @@ class DOMParser
                     ]);
                 }
 
-                if ($wrapper = $class::wrapper($child)) {
+                if (is_subclass_of($class, Node::class) && $wrapper = $class::wrapper($child)) {
                     $item['content'] = [
                         array_merge($wrapper, [
                             'content' => @$item['content'] ?: [],

--- a/src/DOMParser.php
+++ b/src/DOMParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/DOMParser.php
+++ b/src/DOMParser.php
@@ -60,11 +60,6 @@ class DOMParser
         return (new Minify)->process($value);
     }
 
-    private function getDocumentBody(): DOMNode
-    {
-        return $this->document->getElementsByTagName('body')->item(0);
-    }
-
     private function renderChildren(DOMNode $node): array
     {
         $nodes = [];
@@ -161,14 +156,6 @@ class DOMParser
     private function getMatchingNode(DOMNode $item)
     {
         return $this->getMatchingClass($item, $this->schema->nodes);
-    }
-
-    /**
-     * @return false|Mark|Node
-     */
-    private function getMatchingMark(DOMNode $item)
-    {
-        return $this->getMatchingClass($item, $this->schema->marks);
     }
 
     /**
@@ -347,5 +334,18 @@ class DOMParser
         }
 
         return $item;
+    }
+
+    /**
+     * @return false|Mark|Node
+     */
+    private function getMatchingMark(DOMNode $item)
+    {
+        return $this->getMatchingClass($item, $this->schema->marks);
+    }
+
+    private function getDocumentBody(): DOMNode
+    {
+        return $this->document->getElementsByTagName('body')->item(0);
     }
 }

--- a/src/DOMSerializer.php
+++ b/src/DOMSerializer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/DOMSerializer.php
+++ b/src/DOMSerializer.php
@@ -192,7 +192,7 @@ class DOMSerializer
                 // 'table'
                 if (is_string($renderInstruction)) {
                     // next item: ['class' => 'foobar']
-                    if ($nextTag = $renderHTML[$index + 1] ?? null) {
+                    if ($nextTag = $renderHTML[(int)$index + 1] ?? null) {
                         if (is_array($nextTag) && ! in_array(0, $nextTag, true)) {
                             $attributes = HTML::renderAttributes($nextTag);
 

--- a/src/DOMSerializer.php
+++ b/src/DOMSerializer.php
@@ -84,8 +84,7 @@ class DOMSerializer
         $lastElement = $html[array_key_last($html)] ?? null;
         if (isset($lastElement['content'])) {
             $html[array_key_last($html)] = $lastElement['content'];
-        }
-        // child nodes
+        } // child nodes
         elseif (isset($node->content)) {
             foreach ($node->content as $index => $nestedNode) {
                 $previousNestedNode = $node->content[$index - 1] ?? null;
@@ -93,8 +92,7 @@ class DOMSerializer
 
                 $html[] = $this->renderNode($nestedNode, $previousNestedNode, $nextNestedNode);
             }
-        }
-        // text
+        } // text
         elseif (isset($node->text)) {
             $html[] = htmlspecialchars($node->text, ENT_QUOTES);
         }
@@ -134,11 +132,6 @@ class DOMSerializer
     private function markShouldOpen($mark, $previousNode): bool
     {
         return $this->nodeHasMark($previousNode, $mark);
-    }
-
-    private function markShouldClose($mark, $nextNode): bool
-    {
-        return $this->nodeHasMark($nextNode, $mark);
     }
 
     private function nodeHasMark($node, $mark): bool
@@ -277,8 +270,7 @@ class DOMSerializer
                         return null;
                     }
                     $html[] = "</{$renderInstruction}>";
-                }
-                // ['tbody', 0]
+                } // ['tbody', 0]
                 elseif (is_array($renderInstruction) && in_array(0, $renderInstruction)) {
                     $html[] = $this->renderClosingTag($renderInstruction);
                 }
@@ -301,5 +293,10 @@ class DOMSerializer
         $rendered = $dom->saveHTML();
 
         return substr_count($rendered, $tag) === 1;
+    }
+
+    private function markShouldClose($mark, $nextNode): bool
+    {
+        return $this->nodeHasMark($nextNode, $mark);
     }
 }

--- a/src/DOMSerializerPointer.php
+++ b/src/DOMSerializerPointer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/Editor.php
+++ b/src/Editor.php
@@ -7,11 +7,9 @@ use Tiptap\Extensions\StarterKit;
 
 class Editor
 {
-    protected array $document;
-
     public Schema $schema;
-
     public array $configuration = [];
+    protected array $document;
 
     public function __construct(array $configuration = [])
     {
@@ -44,41 +42,6 @@ class Editor
         return $this;
     }
 
-    public function getDocument(): array
-    {
-        return $this->document;
-    }
-
-    public function getJSON()
-    {
-        return json_encode($this->document);
-    }
-
-    public function getText($configuration = []): string
-    {
-        return (new TextSerializer($this->schema, $configuration))->render($this->document);
-    }
-
-    public function getHTML(): string
-    {
-        return (new DOMSerializer($this->schema))->render($this->document);
-    }
-
-    /**
-     * @return array|false|string
-     * @throws Exception
-     */
-    public function sanitize($value)
-    {
-        if ($this->getContentType($value) === 'HTML') {
-            return $this->setContent($value)->getHTML();
-        } elseif ($this->getContentType($value) === 'Array') {
-            return $this->setContent($value)->getDocument();
-        }
-
-        return $this->setContent($value)->getJSON();
-    }
-
     public function getContentType($value): string
     {
         if (is_string($value)) {
@@ -99,6 +62,41 @@ class Editor
         }
 
         throw new Exception('Unknown format passed to setContent().');
+    }
+
+    public function getText($configuration = []): string
+    {
+        return (new TextSerializer($this->schema, $configuration))->render($this->document);
+    }
+
+    /**
+     * @return array|false|string
+     * @throws Exception
+     */
+    public function sanitize($value)
+    {
+        if ($this->getContentType($value) === 'HTML') {
+            return $this->setContent($value)->getHTML();
+        } elseif ($this->getContentType($value) === 'Array') {
+            return $this->setContent($value)->getDocument();
+        }
+
+        return $this->setContent($value)->getJSON();
+    }
+
+    public function getHTML(): string
+    {
+        return (new DOMSerializer($this->schema))->render($this->document);
+    }
+
+    public function getDocument(): array
+    {
+        return $this->document;
+    }
+
+    public function getJSON()
+    {
+        return json_encode($this->document);
     }
 
     public function descendants($closure): self

--- a/src/Editor.php
+++ b/src/Editor.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/Editor.php
+++ b/src/Editor.php
@@ -7,11 +7,11 @@ use Tiptap\Extensions\StarterKit;
 
 class Editor
 {
-    protected $document;
+    protected array $document;
 
-    public $schema;
+    public Schema $schema;
 
-    public $configuration = [];
+    public array $configuration = [];
 
     public function __construct(array $configuration = [])
     {
@@ -29,7 +29,7 @@ class Editor
         }
     }
 
-    public function setContent($value)
+    public function setContent($value): self
     {
         if ($this->getContentType($value) === 'HTML') {
             $this->document = (new DOMParser($this->schema))->render($value);
@@ -44,7 +44,7 @@ class Editor
         return $this;
     }
 
-    public function getDocument()
+    public function getDocument(): array
     {
         return $this->document;
     }
@@ -54,28 +54,32 @@ class Editor
         return json_encode($this->document);
     }
 
-    public function getText($configuration = [])
+    public function getText($configuration = []): string
     {
         return (new TextSerializer($this->schema, $configuration))->render($this->document);
     }
 
-    public function getHTML()
+    public function getHTML(): string
     {
         return (new DOMSerializer($this->schema))->render($this->document);
     }
 
+    /**
+     * @return array|false|string
+     * @throws Exception
+     */
     public function sanitize($value)
     {
         if ($this->getContentType($value) === 'HTML') {
             return $this->setContent($value)->getHTML();
         } elseif ($this->getContentType($value) === 'Array') {
             return $this->setContent($value)->getDocument();
-        } elseif ($this->getContentType($value) === 'JSON') {
-            return $this->setContent($value)->getJSON();
         }
+
+        return $this->setContent($value)->getJSON();
     }
 
-    public function getContentType($value)
+    public function getContentType($value): string
     {
         if (is_string($value)) {
             try {
@@ -97,7 +101,7 @@ class Editor
         throw new Exception('Unknown format passed to setContent().');
     }
 
-    public function descendants($closure)
+    public function descendants($closure): self
     {
         // Transform the document to an object
         $node = json_decode(json_encode($this->document));

--- a/src/Extensions/StarterKit.php
+++ b/src/Extensions/StarterKit.php
@@ -3,12 +3,26 @@
 namespace Tiptap\Extensions;
 
 use Tiptap\Core\Extension;
+use Tiptap\Marks\Bold;
+use Tiptap\Marks\Code;
+use Tiptap\Marks\Italic;
+use Tiptap\Marks\Strike;
+use Tiptap\Nodes\Blockquote;
+use Tiptap\Nodes\BulletList;
+use Tiptap\Nodes\CodeBlock;
+use Tiptap\Nodes\HardBreak;
+use Tiptap\Nodes\Heading;
+use Tiptap\Nodes\HorizontalRule;
+use Tiptap\Nodes\ListItem;
+use Tiptap\Nodes\OrderedList;
+use Tiptap\Nodes\Paragraph;
+use Tiptap\Nodes\Text;
 
 class StarterKit extends Extension
 {
-    public static $name = 'starterKit';
+    public static string $name = 'starterKit';
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'blockquote' => [],
@@ -28,51 +42,49 @@ class StarterKit extends Extension
         ];
     }
 
-    public function addExtensions()
+    public function addExtensions(): array
     {
         return array_filter([
             $this->options['blockquote'] !== false
-                ? new \Tiptap\Nodes\Blockquote($this->options['blockquote'])
+                ? new Blockquote($this->options['blockquote'])
                 : null,
             $this->options['bulletList'] !== false
-                ? new \Tiptap\Nodes\BulletList($this->options['bulletList'])
+                ? new BulletList($this->options['bulletList'])
                 : null,
             $this->options['codeBlock'] !== false
-                ? new \Tiptap\Nodes\CodeBlock($this->options['codeBlock'])
+                ? new CodeBlock($this->options['codeBlock'])
                 : null,
             $this->options['hardBreak'] !== false
-                ? new \Tiptap\Nodes\HardBreak($this->options['hardBreak'])
+                ? new HardBreak($this->options['hardBreak'])
                 : null,
             $this->options['heading'] !== false
-                ? new \Tiptap\Nodes\Heading($this->options['heading'])
+                ? new Heading($this->options['heading'])
                 : null,
             $this->options['horizontalRule'] !== false
-                ? new \Tiptap\Nodes\HorizontalRule($this->options['horizontalRule'])
+                ? new HorizontalRule($this->options['horizontalRule'])
                 : null,
             $this->options['listItem'] !== false
-                ? new \Tiptap\Nodes\ListItem($this->options['listItem'])
+                ? new ListItem($this->options['listItem'])
                 : null,
             $this->options['orderedList'] !== false
-                ? new \Tiptap\Nodes\OrderedList($this->options['orderedList'])
+                ? new OrderedList($this->options['orderedList'])
                 : null,
             $this->options['paragraph'] !== false
-                ? new \Tiptap\Nodes\Paragraph($this->options['paragraph'])
+                ? new Paragraph($this->options['paragraph'])
                 : null,
             $this->options['text'] !== false
-                ? new \Tiptap\Nodes\Text($this->options['text'])
+                ? new Text($this->options['text'])
                 : null,
             $this->options['bold'] !== false
-                ? new \Tiptap\Marks\Bold($this->options['bold'])
+                ? new Bold($this->options['bold'])
                 : null,
             $this->options['code'] !== false
-                ? new \Tiptap\Marks\Code($this->options['code'])
+                ? new Code($this->options['code'])
                 : null,
             $this->options['italic'] !== false
-                ? new \Tiptap\Marks\Italic($this->options['italic'])
+                ? new Italic($this->options['italic'])
                 : null,
-            $this->options['strike'] !== false
-                ? new \Tiptap\Marks\Strike($this->options['strike'])
-                : null,
+            $this->options['strike'] !== false ? new Strike($this->options['strike']) : null,
         ]);
     }
 }

--- a/src/Extensions/StarterKit.php
+++ b/src/Extensions/StarterKit.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Extensions;
 

--- a/src/Marks/Bold.php
+++ b/src/Marks/Bold.php
@@ -8,7 +8,7 @@ use Tiptap\Utils\InlineStyle;
 
 class Bold extends Mark
 {
-    public static $name = 'bold';
+    public static string $name = 'bold';
 
     public function parseHTML(): array
     {
@@ -27,7 +27,7 @@ class Bold extends Mark
             [
                 'style' => 'font-weight',
                 'getAttrs' => function ($value) {
-                    return (bool) preg_match('/^(bold(er)?|[5-9]\d{2,})$/', $value) ? null : false;
+                    return preg_match('/^(bold(er)?|[5-9]\d{2,})$/', $value) ? null : false;
                 },
             ],
         ];

--- a/src/Marks/Bold.php
+++ b/src/Marks/Bold.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Bold.php
+++ b/src/Marks/Bold.php
@@ -33,7 +33,7 @@ class Bold extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return [
             'strong',

--- a/src/Marks/Bold.php
+++ b/src/Marks/Bold.php
@@ -10,14 +10,7 @@ class Bold extends Mark
 {
     public static $name = 'bold';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -40,7 +33,7 @@ class Bold extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return [
             'strong',

--- a/src/Marks/Code.php
+++ b/src/Marks/Code.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Code extends Mark
 {
-    public static $name = 'code';
+    public static string $name = 'code';
 
     public function parseHTML(): array
     {

--- a/src/Marks/Code.php
+++ b/src/Marks/Code.php
@@ -18,7 +18,7 @@ class Code extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['code', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Code.php
+++ b/src/Marks/Code.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Code.php
+++ b/src/Marks/Code.php
@@ -9,14 +9,7 @@ class Code extends Mark
 {
     public static $name = 'code';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class Code extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['code', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Highlight.php
+++ b/src/Marks/Highlight.php
@@ -56,7 +56,7 @@ class Highlight extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return [
             'mark',

--- a/src/Marks/Highlight.php
+++ b/src/Marks/Highlight.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Highlight.php
+++ b/src/Marks/Highlight.php
@@ -8,9 +8,9 @@ use Tiptap\Utils\InlineStyle;
 
 class Highlight extends Mark
 {
-    public static $name = 'highlight';
+    public static string $name = 'highlight';
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'multicolor' => false,
@@ -27,7 +27,7 @@ class Highlight extends Mark
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         if (! $this->options['multicolor']) {
             return [];

--- a/src/Marks/Highlight.php
+++ b/src/Marks/Highlight.php
@@ -18,7 +18,7 @@ class Highlight extends Mark
         ];
     }
 
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -56,7 +56,7 @@ class Highlight extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return [
             'mark',

--- a/src/Marks/Italic.php
+++ b/src/Marks/Italic.php
@@ -10,14 +10,7 @@ class Italic extends Mark
 {
     public static $name = 'italic';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -41,7 +34,7 @@ class Italic extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['em', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Italic.php
+++ b/src/Marks/Italic.php
@@ -8,7 +8,7 @@ use Tiptap\Utils\InlineStyle;
 
 class Italic extends Mark
 {
-    public static $name = 'italic';
+    public static string $name = 'italic';
 
     public function parseHTML(): array
     {

--- a/src/Marks/Italic.php
+++ b/src/Marks/Italic.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Italic.php
+++ b/src/Marks/Italic.php
@@ -34,7 +34,7 @@ class Italic extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['em', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -37,7 +37,7 @@ class Link extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return [
             'a',

--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -7,9 +7,9 @@ use Tiptap\Utils\HTML;
 
 class Link extends Mark
 {
-    public static $name = 'link';
+    public static string $name = 'link';
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'HTMLAttributes' => [
@@ -28,7 +28,7 @@ class Link extends Mark
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         return [
             'href' => [],

--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -19,7 +19,7 @@ class Link extends Mark
         ];
     }
 
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -37,7 +37,7 @@ class Link extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return [
             'a',

--- a/src/Marks/Strike.php
+++ b/src/Marks/Strike.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Strike extends Mark
 {
-    public static $name = 'strike';
+    public static string $name = 'strike';
 
     public function parseHTML(): array
     {

--- a/src/Marks/Strike.php
+++ b/src/Marks/Strike.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Strike.php
+++ b/src/Marks/Strike.php
@@ -30,7 +30,7 @@ class Strike extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['strike', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Strike.php
+++ b/src/Marks/Strike.php
@@ -9,14 +9,7 @@ class Strike extends Mark
 {
     public static $name = 'strike';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -37,7 +30,7 @@ class Strike extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['strike', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Subscript.php
+++ b/src/Marks/Subscript.php
@@ -24,7 +24,7 @@ class Subscript extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['sub', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Subscript.php
+++ b/src/Marks/Subscript.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Subscript.php
+++ b/src/Marks/Subscript.php
@@ -9,14 +9,7 @@ class Subscript extends Mark
 {
     public static $name = 'subscript';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -31,7 +24,7 @@ class Subscript extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['sub', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Subscript.php
+++ b/src/Marks/Subscript.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Subscript extends Mark
 {
-    public static $name = 'subscript';
+    public static string $name = 'subscript';
 
     public function parseHTML(): array
     {

--- a/src/Marks/Superscript.php
+++ b/src/Marks/Superscript.php
@@ -9,14 +9,7 @@ class Superscript extends Mark
 {
     public static $name = 'superscript';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -31,7 +24,7 @@ class Superscript extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['sup', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Superscript.php
+++ b/src/Marks/Superscript.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Superscript.php
+++ b/src/Marks/Superscript.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Superscript extends Mark
 {
-    public static $name = 'superscript';
+    public static string $name = 'superscript';
 
     public function parseHTML(): array
     {

--- a/src/Marks/Superscript.php
+++ b/src/Marks/Superscript.php
@@ -24,7 +24,7 @@ class Superscript extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['sup', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/TextStyle.php
+++ b/src/Marks/TextStyle.php
@@ -9,14 +9,7 @@ class TextStyle extends Mark
 {
     public static $name = 'textStyle';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -28,7 +21,7 @@ class TextStyle extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['span', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/TextStyle.php
+++ b/src/Marks/TextStyle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/TextStyle.php
+++ b/src/Marks/TextStyle.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class TextStyle extends Mark
 {
-    public static $name = 'textStyle';
+    public static string $name = 'textStyle';
 
     public function parseHTML(): array
     {

--- a/src/Marks/TextStyle.php
+++ b/src/Marks/TextStyle.php
@@ -21,7 +21,7 @@ class TextStyle extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['span', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Underline.php
+++ b/src/Marks/Underline.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Underline extends Mark
 {
-    public static $name = 'underline';
+    public static string $name = 'underline';
 
     public function parseHTML(): array
     {

--- a/src/Marks/Underline.php
+++ b/src/Marks/Underline.php
@@ -9,14 +9,7 @@ class Underline extends Mark
 {
     public static $name = 'underline';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -31,7 +24,7 @@ class Underline extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = [])
+    public function renderHTML($mark, $HTMLAttributes = []): array
     {
         return ['u', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Marks/Underline.php
+++ b/src/Marks/Underline.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Marks;
 

--- a/src/Marks/Underline.php
+++ b/src/Marks/Underline.php
@@ -24,7 +24,7 @@ class Underline extends Mark
         ];
     }
 
-    public function renderHTML($mark, $HTMLAttributes = []): array
+    public function renderHTML($mark, array $HTMLAttributes = []): array
     {
         return ['u', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -12,7 +12,7 @@ class Minify
     {
         $this->_html = str_replace("\r\n", "\n", trim($html));
 
-        $this->_replacementHash = 'MINIFYHTML' . md5($_SERVER['REQUEST_TIME']);
+        $this->_replacementHash = 'MINIFYHTML' . md5((string)$_SERVER['REQUEST_TIME']);
 
         // replace PREs with placeholders
         $this->_html = preg_replace_callback('/\\s*<pre(\\b[^>]*?>[\\s\\S]*?<\\/pre>)\\s*/iu', [$this, '_removePreCB'], $this->_html);

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -4,11 +4,11 @@ namespace Tiptap;
 
 class Minify
 {
-    protected $_replacementHash;
-    protected $_placeholders = [];
-    protected $_html;
+    protected array $_placeholders = [];
+    protected string $_replacementHash;
+    protected string $_html;
 
-    public function process($html)
+    public function process(string $html)
     {
         $this->_html = str_replace("\r\n", "\n", trim($html));
 
@@ -37,12 +37,12 @@ class Minify
         return $this->_html;
     }
 
-    protected function _removePreCB($m)
+    protected function _removePreCB(array $m): string
     {
         return $this->_reservePlace("<pre{$m[1]}");
     }
 
-    protected function _reservePlace($content)
+    protected function _reservePlace(string $content): string
     {
         $placeholder = '%' . $this->_replacementHash . count($this->_placeholders) . '%';
         $this->_placeholders[$placeholder] = $content;

--- a/src/NewDOMSerializer.php
+++ b/src/NewDOMSerializer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/Nodes/Blockquote.php
+++ b/src/Nodes/Blockquote.php
@@ -18,7 +18,7 @@ class Blockquote extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['blockquote', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/Blockquote.php
+++ b/src/Nodes/Blockquote.php
@@ -9,14 +9,7 @@ class Blockquote extends Node
 {
     public static $name = 'blockquote';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class Blockquote extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['blockquote', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/Blockquote.php
+++ b/src/Nodes/Blockquote.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Blockquote.php
+++ b/src/Nodes/Blockquote.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Blockquote extends Node
 {
-    public static $name = 'blockquote';
+    public static string $name = 'blockquote';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/BulletList.php
+++ b/src/Nodes/BulletList.php
@@ -18,7 +18,7 @@ class BulletList extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['ul', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/BulletList.php
+++ b/src/Nodes/BulletList.php
@@ -9,14 +9,7 @@ class BulletList extends Node
 {
     public static $name = 'bulletList';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class BulletList extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['ul', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/BulletList.php
+++ b/src/Nodes/BulletList.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class BulletList extends Node
 {
-    public static $name = 'bulletList';
+    public static string $name = 'bulletList';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/BulletList.php
+++ b/src/Nodes/BulletList.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -34,7 +34,7 @@ class CodeBlock extends Node
             'language' => [
                 'parseHTML' => function ($DOMNode) {
                     return preg_replace(
-                        "/^" . $this->options['languageClassPrefix']. "/",
+                        "/^" . $this->options['languageClassPrefix'] . "/",
                         "",
                         $DOMNode->childNodes[0]->getAttribute('class')
                     ) ?: null;
@@ -53,8 +53,8 @@ class CodeBlock extends Node
                 'code',
                 [
                     'class' => $node->attrs->language ?? null
-                        ? $this->options['languageClassPrefix'] . $node->attrs->language
-                        : null,
+                            ? $this->options['languageClassPrefix'] . $node->attrs->language
+                            : null,
                 ],
                 0,
             ],

--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -7,9 +7,9 @@ use Tiptap\Utils\HTML;
 
 class CodeBlock extends Node
 {
-    public static $name = 'codeBlock';
+    public static string $name = 'codeBlock';
 
-    public static $marks = '';
+    public static string $marks = '';
 
     public function addOptions(): array
     {
@@ -28,7 +28,7 @@ class CodeBlock extends Node
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         return [
             'language' => [

--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -11,7 +11,7 @@ class CodeBlock extends Node
 
     public static $marks = '';
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'languageClassPrefix' => 'language-',
@@ -19,7 +19,7 @@ class CodeBlock extends Node
         ];
     }
 
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -44,7 +44,7 @@ class CodeBlock extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return [
             'pre',

--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -44,7 +44,7 @@ class CodeBlock extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return [
             'pre',

--- a/src/Nodes/CodeBlockHighlight.php
+++ b/src/Nodes/CodeBlockHighlight.php
@@ -34,7 +34,8 @@ class CodeBlockHighlight extends CodeBlock
                     'class' => $this->options['languageClassPrefix'] . $result->language,
                 ],
                 array_merge(
-                    $this->options['HTMLAttributes'], $HTMLAttributes
+                    $this->options['HTMLAttributes'],
+                    $HTMLAttributes
                 ),
             );
 

--- a/src/Nodes/CodeBlockHighlight.php
+++ b/src/Nodes/CodeBlockHighlight.php
@@ -8,7 +8,7 @@ use Tiptap\Utils\HTML;
 
 class CodeBlockHighlight extends CodeBlock
 {
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'languageClassPrefix' => 'hljs ',
@@ -16,7 +16,7 @@ class CodeBlockHighlight extends CodeBlock
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         $code = $node->content[0]->text ?? null;
 
@@ -34,7 +34,7 @@ class CodeBlockHighlight extends CodeBlock
                     'class' => $this->options['languageClassPrefix'] . $result->language,
                 ],
                 $this->options['HTMLAttributes'],
-                $HTMLAttributes,
+                $HTMLAttributes, // TODO third parameter not supported, maybe merge spreaded elements into array of second argument
             );
 
             $renderedAttributes = HTML::renderAttributes($mergedAttributes);

--- a/src/Nodes/CodeBlockHighlight.php
+++ b/src/Nodes/CodeBlockHighlight.php
@@ -33,8 +33,9 @@ class CodeBlockHighlight extends CodeBlock
                 [
                     'class' => $this->options['languageClassPrefix'] . $result->language,
                 ],
-                $this->options['HTMLAttributes'],
-                $HTMLAttributes, // TODO third parameter not supported, maybe merge spreaded elements into array of second argument
+                array_merge(
+                    $this->options['HTMLAttributes'], $HTMLAttributes
+                ),
             );
 
             $renderedAttributes = HTML::renderAttributes($mergedAttributes);

--- a/src/Nodes/CodeBlockHighlight.php
+++ b/src/Nodes/CodeBlockHighlight.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/HardBreak.php
+++ b/src/Nodes/HardBreak.php
@@ -9,14 +9,7 @@ class HardBreak extends Node
 {
     public static $name = 'hardBreak';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class HardBreak extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['br', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes)];
     }

--- a/src/Nodes/HardBreak.php
+++ b/src/Nodes/HardBreak.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/HardBreak.php
+++ b/src/Nodes/HardBreak.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class HardBreak extends Node
 {
-    public static $name = 'hardBreak';
+    public static string $name = 'hardBreak';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/HardBreak.php
+++ b/src/Nodes/HardBreak.php
@@ -18,7 +18,7 @@ class HardBreak extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['br', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes)];
     }

--- a/src/Nodes/Heading.php
+++ b/src/Nodes/Heading.php
@@ -9,7 +9,7 @@ class Heading extends Node
 {
     public static $name = 'heading';
 
-    public function addOptions()
+    public function addOptions(): array
     {
         return [
             'levels' => [1, 2, 3, 4, 5, 6],
@@ -17,7 +17,7 @@ class Heading extends Node
         ];
     }
 
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return array_map(function ($level) {
             return [
@@ -29,7 +29,7 @@ class Heading extends Node
         }, $this->options['levels']);
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         $hasLevel = in_array($node->attrs->level, $this->options['levels']);
 

--- a/src/Nodes/Heading.php
+++ b/src/Nodes/Heading.php
@@ -29,7 +29,7 @@ class Heading extends Node
         }, $this->options['levels']);
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         $hasLevel = in_array($node->attrs->level, $this->options['levels']);
 

--- a/src/Nodes/Heading.php
+++ b/src/Nodes/Heading.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Heading.php
+++ b/src/Nodes/Heading.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Heading extends Node
 {
-    public static $name = 'heading';
+    public static string $name = 'heading';
 
     public function addOptions(): array
     {

--- a/src/Nodes/HorizontalRule.php
+++ b/src/Nodes/HorizontalRule.php
@@ -9,14 +9,7 @@ class HorizontalRule extends Node
 {
     public static $name = 'horizontalRule';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class HorizontalRule extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['hr', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes)];
     }

--- a/src/Nodes/HorizontalRule.php
+++ b/src/Nodes/HorizontalRule.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class HorizontalRule extends Node
 {
-    public static $name = 'horizontalRule';
+    public static string $name = 'horizontalRule';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/HorizontalRule.php
+++ b/src/Nodes/HorizontalRule.php
@@ -18,7 +18,7 @@ class HorizontalRule extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['hr', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes)];
     }

--- a/src/Nodes/HorizontalRule.php
+++ b/src/Nodes/HorizontalRule.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Image.php
+++ b/src/Nodes/Image.php
@@ -27,7 +27,7 @@ class Image extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['img', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/Image.php
+++ b/src/Nodes/Image.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Image extends Node
 {
-    public static $name = 'image';
+    public static string $name = 'image';
 
     public function parseHTML(): array
     {
@@ -18,7 +18,7 @@ class Image extends Node
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         return [
             'src' => [],

--- a/src/Nodes/Image.php
+++ b/src/Nodes/Image.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Image.php
+++ b/src/Nodes/Image.php
@@ -9,14 +9,7 @@ class Image extends Node
 {
     public static $name = 'image';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -34,7 +27,7 @@ class Image extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['img', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -9,20 +9,6 @@ class ListItem extends Node
 {
     public static string $name = 'listItem';
 
-    public function parseHTML(): array
-    {
-        return [
-            [
-                'tag' => 'li',
-            ],
-        ];
-    }
-
-    public function renderHTML($node, array $HTMLAttributes = []): ?array
-    {
-        return ['li', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
-    }
-
     public static function wrapper($DOMNode): ?array
     {
         if (
@@ -35,5 +21,19 @@ class ListItem extends Node
         return [
             'type' => 'paragraph',
         ];
+    }
+
+    public function parseHTML(): array
+    {
+        return [
+            [
+                'tag' => 'li',
+            ],
+        ];
+    }
+
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
+    {
+        return ['li', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }
 }

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class ListItem extends Node
 {
-    public static $name = 'listItem';
+    public static string $name = 'listItem';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -9,14 +9,7 @@ class ListItem extends Node
 {
     public static $name = 'listItem';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,12 +18,12 @@ class ListItem extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['li', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }
 
-    public static function wrapper($DOMNode)
+    public static function wrapper($DOMNode): ?array
     {
         if (
             $DOMNode->childNodes->length === 1

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -18,7 +18,7 @@ class ListItem extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['li', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/Mention.php
+++ b/src/Nodes/Mention.php
@@ -8,14 +8,7 @@ class Mention extends Node
 {
     public static $name = 'mention';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [

--- a/src/Nodes/Mention.php
+++ b/src/Nodes/Mention.php
@@ -6,7 +6,7 @@ use Tiptap\Core\Node;
 
 class Mention extends Node
 {
-    public static $name = 'mention';
+    public static string $name = 'mention';
 
     public function parseHTML(): array
     {
@@ -17,7 +17,7 @@ class Mention extends Node
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         return [
             'id' => [

--- a/src/Nodes/Mention.php
+++ b/src/Nodes/Mention.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class OrderedList extends Node
 {
-    public static $name = 'orderedList';
+    public static string $name = 'orderedList';
 
     public function parseHTML(): array
     {
@@ -18,7 +18,7 @@ class OrderedList extends Node
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         return [
             'order' => [

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -28,6 +28,9 @@ class OrderedList extends Node
         ];
     }
 
+    /**
+     * @psalm-suppress UnusedVariable
+     */
     public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         // TODO: Move to `addAttributes`

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -22,7 +22,7 @@ class OrderedList extends Node
     {
         return [
             'order' => [
-                'parseHTML' => fn ($DOMNode) => (int) $DOMNode->getAttribute('start') ?: null,
+                'parseHTML' => fn ($DOMNode) => (int)$DOMNode->getAttribute('start') ?: null,
                 'renderHTML' => fn ($attributes) => ($attributes->order ?? null) ? ['start' => $attributes->order] : null,
             ],
         ];

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -28,7 +28,7 @@ class OrderedList extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         // TODO: Move to `addAttributes`
         $attrs = [];

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -9,14 +9,7 @@ class OrderedList extends Node
 {
     public static $name = 'orderedList';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -35,7 +28,7 @@ class OrderedList extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         // TODO: Move to `addAttributes`
         $attrs = [];

--- a/src/Nodes/Paragraph.php
+++ b/src/Nodes/Paragraph.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Paragraph extends Node
 {
-    public static $name = 'paragraph';
+    public static string $name = 'paragraph';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/Paragraph.php
+++ b/src/Nodes/Paragraph.php
@@ -9,14 +9,7 @@ class Paragraph extends Node
 {
     public static $name = 'paragraph';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class Paragraph extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['p', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/Paragraph.php
+++ b/src/Nodes/Paragraph.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Paragraph.php
+++ b/src/Nodes/Paragraph.php
@@ -18,7 +18,7 @@ class Paragraph extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['p', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/Table.php
+++ b/src/Nodes/Table.php
@@ -18,7 +18,7 @@ class Table extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return [
             'table',

--- a/src/Nodes/Table.php
+++ b/src/Nodes/Table.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class Table extends Node
 {
-    public static $name = 'table';
+    public static string $name = 'table';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/Table.php
+++ b/src/Nodes/Table.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Table.php
+++ b/src/Nodes/Table.php
@@ -9,14 +9,7 @@ class Table extends Node
 {
     public static $name = 'table';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class Table extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return [
             'table',

--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -6,7 +6,7 @@ use Tiptap\Core\Node;
 
 class TableCell extends Node
 {
-    public static $name = 'tableCell';
+    public static string $name = 'tableCell';
 
     public function parseHTML(): array
     {
@@ -17,7 +17,7 @@ class TableCell extends Node
         ];
     }
 
-    public function addAttributes()
+    public function addAttributes(): array
     {
         return [
             'rowspan' => [
@@ -49,7 +49,7 @@ class TableCell extends Node
         ];
     }
 
-    protected static function getAttrs($node)
+    protected static function getAttrs($node): array
     {
         $attrs = [];
 

--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -8,14 +8,7 @@ class TableCell extends Node
 {
     public static $name = 'tableCell';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -81,7 +74,7 @@ class TableCell extends Node
         return $attrs;
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         // TODO: Add HTML Attributes
         return [

--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -74,7 +74,7 @@ class TableCell extends Node
         return $attrs;
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         // TODO: Add HTML Attributes
         return [

--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -49,6 +49,16 @@ class TableCell extends Node
         ];
     }
 
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
+    {
+        // TODO: Add HTML Attributes
+        return [
+            'td',
+            self::getAttrs($node),
+            0,
+        ];
+    }
+
     protected static function getAttrs($node): array
     {
         $attrs = [];
@@ -72,15 +82,5 @@ class TableCell extends Node
         }
 
         return $attrs;
-    }
-
-    public function renderHTML($node, array $HTMLAttributes = []): ?array
-    {
-        // TODO: Add HTML Attributes
-        return [
-            'td',
-            self::getAttrs($node),
-            0,
-        ];
     }
 }

--- a/src/Nodes/TableHeader.php
+++ b/src/Nodes/TableHeader.php
@@ -15,7 +15,7 @@ class TableHeader extends TableCell
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         // TODO: Add HTMLAttributes
         return ['th', self::getAttrs($node), 0];

--- a/src/Nodes/TableHeader.php
+++ b/src/Nodes/TableHeader.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/TableHeader.php
+++ b/src/Nodes/TableHeader.php
@@ -4,7 +4,7 @@ namespace Tiptap\Nodes;
 
 class TableHeader extends TableCell
 {
-    public static $name = 'tableHeader';
+    public static string $name = 'tableHeader';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/TableHeader.php
+++ b/src/Nodes/TableHeader.php
@@ -6,14 +6,7 @@ class TableHeader extends TableCell
 {
     public static $name = 'tableHeader';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -22,7 +15,7 @@ class TableHeader extends TableCell
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         // TODO: Add HTMLAttributes
         return ['th', self::getAttrs($node), 0];

--- a/src/Nodes/TableRow.php
+++ b/src/Nodes/TableRow.php
@@ -18,7 +18,7 @@ class TableRow extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = []): ?array
+    public function renderHTML($node, array $HTMLAttributes = []): ?array
     {
         return ['tr', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/TableRow.php
+++ b/src/Nodes/TableRow.php
@@ -7,7 +7,7 @@ use Tiptap\Utils\HTML;
 
 class TableRow extends Node
 {
-    public static $name = 'tableRow';
+    public static string $name = 'tableRow';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/TableRow.php
+++ b/src/Nodes/TableRow.php
@@ -9,14 +9,7 @@ class TableRow extends Node
 {
     public static $name = 'tableRow';
 
-    public function addOptions()
-    {
-        return [
-            'HTMLAttributes' => [],
-        ];
-    }
-
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [
@@ -25,7 +18,7 @@ class TableRow extends Node
         ];
     }
 
-    public function renderHTML($node, $HTMLAttributes = [])
+    public function renderHTML($node, $HTMLAttributes = []): ?array
     {
         return ['tr', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }

--- a/src/Nodes/TableRow.php
+++ b/src/Nodes/TableRow.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Text.php
+++ b/src/Nodes/Text.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Nodes;
 

--- a/src/Nodes/Text.php
+++ b/src/Nodes/Text.php
@@ -6,7 +6,7 @@ use Tiptap\Core\Node;
 
 class Text extends Node
 {
-    public static $name = 'text';
+    public static string $name = 'text';
 
     public function parseHTML(): array
     {

--- a/src/Nodes/Text.php
+++ b/src/Nodes/Text.php
@@ -8,7 +8,7 @@ class Text extends Node
 {
     public static $name = 'text';
 
-    public function parseHTML()
+    public function parseHTML(): array
     {
         return [
             [

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -3,19 +3,25 @@
 namespace Tiptap;
 
 use Exception;
+use Tiptap\Core\Mark;
+use Tiptap\Core\Node;
 
+/**
+ * @property array $marks
+ * @property array $nodes
+ */
 class Schema
 {
     public static array $extensions = [];
 
-    public static function from(array $extensions = [])
+    public static function from(array $extensions = []): self
     {
         static::$extensions = self::loadExtensions($extensions);
 
         return new self;
     }
 
-    private static function loadExtensions($extensions = [])
+    private static function loadExtensions(array $extensions = []): array
     {
         foreach ($extensions as $extension) {
             if (method_exists($extension, 'addExtensions') && count($extension->addExtensions())) {
@@ -29,7 +35,7 @@ class Schema
         return $extensions;
     }
 
-    public static function apply($document)
+    public static function apply($document): array
     {
         if (! is_array($document['content'])) {
             return $document;
@@ -77,13 +83,13 @@ class Schema
     {
         if ($name === 'nodes') {
             return array_filter(self::$extensions, function ($extension) {
-                return is_subclass_of($extension, \Tiptap\Core\Node::class);
+                return is_subclass_of($extension, Node::class);
             });
         }
 
         if ($name === 'marks') {
             return array_filter(self::$extensions, function ($extension) {
-                return is_subclass_of($extension, \Tiptap\Core\Mark::class);
+                return is_subclass_of($extension, Mark::class);
             });
         }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/TextSerializer.php
+++ b/src/TextSerializer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap;
 

--- a/src/TextSerializer.php
+++ b/src/TextSerializer.php
@@ -4,21 +4,21 @@ namespace Tiptap;
 
 class TextSerializer
 {
-    protected $document;
+    protected object $document;
 
-    protected $schema;
+    protected Schema $schema;
 
-    protected $configuration = [
+    protected array $configuration = [
         'blockSeparator' => "\n\n",
     ];
 
-    public function __construct($schema, $configuration = [])
+    public function __construct(Schema $schema, array $configuration = [])
     {
         $this->schema = $schema;
         $this->configuration = array_merge($this->configuration, $configuration);
     }
 
-    public function render(array $value)
+    public function render(array $value): string
     {
         $html = [];
 
@@ -27,11 +27,11 @@ class TextSerializer
 
         $content = is_array($this->document->content) ? $this->document->content : [];
 
-        foreach ($content as $index => $node) {
+        foreach ($content as $node) {
             $html[] = $this->renderNode($node);
         }
 
-        return join($this->configuration['blockSeparator'], $html);
+        return implode($this->configuration['blockSeparator'], $html);
     }
 
     private function renderNode($node): string
@@ -39,13 +39,13 @@ class TextSerializer
         $text = [];
 
         if (isset($node->content)) {
-            foreach ($node->content as $index => $nestedNode) {
+            foreach ($node->content as $nestedNode) {
                 $text[] = $this->renderNode($nestedNode);
             }
         } elseif (isset($node->text)) {
-            $text[] = htmlspecialchars($node->text, ENT_QUOTES, 'UTF-8');
+            $text[] = htmlspecialchars($node->text, ENT_QUOTES);
         }
 
-        return join($this->configuration['blockSeparator'], $text);
+        return implode($this->configuration['blockSeparator'], $text);
     }
 }

--- a/src/Utils/HTML.php
+++ b/src/Utils/HTML.php
@@ -4,12 +4,12 @@ namespace Tiptap\Utils;
 
 class HTML
 {
-    public static function mergeAttributes(array $attributes, array $moreAttributes)
+    public static function mergeAttributes(array $attributes, array $moreAttributes): array
     {
         foreach ($moreAttributes as $key => $value) {
             // class="foo bar"
             if ($key === 'class') {
-                $attributes['class'] = trim($attributes['class'] ?? '' . ' ' . $value);
+                $attributes['class'] = trim($attributes['class'] ?? ' ' . $value);
 
                 continue;
             }
@@ -28,7 +28,7 @@ class HTML
         return $attributes;
     }
 
-    public static function renderAttributes(array $attrs)
+    public static function renderAttributes(array $attrs): string
     {
         $attributes = [];
 
@@ -36,6 +36,6 @@ class HTML
             $attributes[] = " {$name}=\"{$value}\"";
         }
 
-        return join($attributes);
+        return implode($attributes);
     }
 }

--- a/src/Utils/HTML.php
+++ b/src/Utils/HTML.php
@@ -32,7 +32,7 @@ class HTML
     {
         $attributes = [];
 
-        foreach (array_filter($attrs) ?? [] as $name => $value) {
+        foreach (array_filter($attrs) as $name => $value) {
             $attributes[] = " {$name}=\"{$value}\"";
         }
 

--- a/src/Utils/HTML.php
+++ b/src/Utils/HTML.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Utils;
 

--- a/src/Utils/InlineStyle.php
+++ b/src/Utils/InlineStyle.php
@@ -7,6 +7,25 @@ use Exception;
 
 class InlineStyle
 {
+    /**
+     * @param string|array $value
+     * @throws Exception
+     */
+    public static function hasAttribute(DOMNode $DOMNode, $value)
+    {
+        $styles = self::get($DOMNode);
+
+        if (is_string($value)) {
+            return in_array($value, array_keys($styles));
+        }
+
+        if (is_array($value)) {
+            return array_diff($value, $styles) == [];
+        }
+
+        throw new Exception('Can’t compare inline styles to ' . json_encode($value));
+    }
+
     public static function get(DOMNode $DOMNode): array
     {
         $results = [];
@@ -29,25 +48,6 @@ class InlineStyle
         }
 
         return $results;
-    }
-
-    /**
-     * @param string|array $value
-     * @throws Exception
-     */
-    public static function hasAttribute(DOMNode $DOMNode, $value)
-    {
-        $styles = self::get($DOMNode);
-
-        if (is_string($value)) {
-            return in_array($value, array_keys($styles));
-        }
-
-        if (is_array($value)) {
-            return array_diff($value, $styles) == [];
-        }
-
-        throw new Exception('Can’t compare inline styles to ' . json_encode($value));
     }
 
     public static function getAttribute(DOMNode $DOMNode, string $attribute): ?string

--- a/src/Utils/InlineStyle.php
+++ b/src/Utils/InlineStyle.php
@@ -2,11 +2,12 @@
 
 namespace Tiptap\Utils;
 
+use DOMNode;
 use Exception;
 
 class InlineStyle
 {
-    public static function get($DOMNode)
+    public static function get(DOMNode $DOMNode): array
     {
         $results = [];
 
@@ -30,7 +31,11 @@ class InlineStyle
         return $results;
     }
 
-    public static function hasAttribute($DOMNode, $value)
+    /**
+     * @param string|array $value
+     * @throws Exception
+     */
+    public static function hasAttribute(DOMNode $DOMNode, $value)
     {
         $styles = self::get($DOMNode);
 
@@ -45,7 +50,7 @@ class InlineStyle
         throw new Exception('Can’t compare inline styles to ' . json_encode($value));
     }
 
-    public static function getAttribute($DOMNode, $attribute)
+    public static function getAttribute(DOMNode $DOMNode, string $attribute): ?string
     {
         return self::get($DOMNode)[$attribute] ?? null;
     }

--- a/src/Utils/InlineStyle.php
+++ b/src/Utils/InlineStyle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tiptap\Utils;
 

--- a/tests/DOMParser/Marks/CustomMarkTest.php
+++ b/tests/DOMParser/Marks/CustomMarkTest.php
@@ -2,12 +2,22 @@
 
 use Tiptap\Editor;
 use Tiptap\Extensions\StarterKit;
+use Tiptap\Utils\HTML;
 
 class CustomMark extends \Tiptap\Core\Mark
 {
-    public static $name = 'custom';
+    public static string $name = 'custom';
 
-    public function parseHTML()
+    public function renderHTML($mark, array $HTMLAttributes = []): array
+    {
+        return [
+            'span',
+            HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes),
+            0,
+        ];
+    }
+
+    public function parseHTML(): array
     {
         return [
             [


### PR DESCRIPTION
This updates the codebase to use types where appropriate and adds PHP 7.4 support.

Changes:
- [x] Add PHP 7.4 support, Fixes #9 
- [x] Add typed properties
- [x] Add typed method parameters
- [x] Add typed return types
- [x] Optimize codestyle (php-cs-fixer, PHPStorm Code optimization)
- [x] Use abstract classes to remove redundent code for `Mark`s and `Node`s

Open:
- [ ] Issue #10 that occures in PHP < 8.0 prevents the tests for PHP 7.4 to pass