### PR TITLE
pull theme from the node options instead of hardcoding

### DIFF
--- a/src/Nodes/CodeBlockShiki.php
+++ b/src/Nodes/CodeBlockShiki.php
@@ -26,9 +26,10 @@ class CodeBlockShiki extends CodeBlock
         $code = $node->content[0]->text ?? '';
 
         // Language is set
-        if ($node->attrs->language === null) {
+        if (isset($node->attrs) && isset($node->attrs->language)) {
             $language = $node->attrs->language;
         }
+        
         // Auto-detect the language
         elseif ($this->options['guessLanguage']) {
             try {

--- a/src/Nodes/CodeBlockShiki.php
+++ b/src/Nodes/CodeBlockShiki.php
@@ -49,7 +49,7 @@ class CodeBlockShiki extends CodeBlock
             $content = Shiki::highlight(
                 code: $code,
                 language: $language,
-                theme: 'nord',
+                theme: $this->options['theme'],
             );
         } catch (DomainException $exception) {
             $mergedAttributes = HTML::mergeAttributes(


### PR DESCRIPTION
When adding the Shiki syntax highlighter, I missed pulling the theme option from the node options, this PR fixes that bug. Thanks again for all the background work to get this pulled in. I learned a ton just looking at the additional commits required to make this work!

Cheers, Wyatt 😎