### PR TITLE
fix: allow text nodes in descendants

### DIFF
--- a/src/Editor.php
+++ b/src/Editor.php
@@ -126,11 +126,6 @@ class Editor
      */
     private function walkThroughNodes(&$node, $closure)
     {
-        // Skip, if it’s just text.
-        if ($node->type === 'text') {
-            return;
-        }
-
         // Call the closure.
         $closure($node);
 


### PR DESCRIPTION
Probably you had something in mind when you implemented the check but I am not sure if it should really belong there? It can still be filtered from implementation side.