### PR TITLE
Add PHP 7.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 8.1]
+        php: [7.4, 8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
         node-version: [16]
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ You can install the package via composer:
 composer require ueberdosis/tiptap-php
 ```
 
-PHP 7.4 support: The package should work with PHP 7.4, but it requires `spatie/shiki-php` which requires PHP 8.0. You can still install the package though, if you pass `--ignore-platform-reqs`. You just won’t be able to use the `CodeBlockShiki` node then.
-
 ## Usage
 The PHP package mimics large parts of the JavaScript package. If you know your way around Tiptap, the PHP syntax will feel familiar to you.
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ use Tiptap\Core\Node;
 class CustomNode extends Node
 {
     public static $name = 'customNode';
+    
+    public static $priority = 100;
 
     public function addOptions()
     {
@@ -346,6 +348,12 @@ class CustomNode extends Node
     }
 }
 ```
+
+#### Extension priority
+
+Extensions are evaluated in the order of descending priority. By default, all Nodes, Marks, and Extensions, have a priority value of `100`.
+
+Priority should be defined when creating a Node extension to match markup that could be matched be other Nodes - an example of this is the [TaskItem Node](src/Nodes/TaskItem.php) which has evaluation priority over the [ListItem Node](src/Nodes/ListItem.php).
 
 ## Testing
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "scrivo/highlight.php": "v9.18.1.9",
-        "spatie/shiki-php": "^1.1"
+        "spatie/shiki-php": "^1.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",

--- a/src/Nodes/CodeBlockShiki.php
+++ b/src/Nodes/CodeBlockShiki.php
@@ -46,11 +46,7 @@ class CodeBlockShiki extends CodeBlock
         }
 
         try {
-            $content = Shiki::highlight(
-                code: $code,
-                language: $language,
-                theme: 'nord',
-            );
+            $content = Shiki::highlight($code, $language, 'nord');
         } catch (DomainException $exception) {
             $mergedAttributes = HTML::mergeAttributes(
                 $this->options['HTMLAttributes'],

--- a/src/Nodes/TaskItem.php
+++ b/src/Nodes/TaskItem.php
@@ -9,6 +9,8 @@ class TaskItem extends Node
 {
     public static $name = 'taskItem';
 
+    public static $priority = 1000;
+
     public function addOptions()
     {
         return [

--- a/src/Nodes/TaskList.php
+++ b/src/Nodes/TaskList.php
@@ -9,6 +9,8 @@ class TaskList extends Node
 {
     public static $name = 'taskList';
 
+    public static $priority = 1000;
+
     public function addOptions()
     {
         return [


### PR DESCRIPTION
I added PHP 7.4 support to Shiki, so tiptap-php does work with PHP 7.4 as well

https://github.com/spatie/shiki-php/releases/tag/1.3.0
