### PR TITLE
Don't fail on missing code tag in code block parsing

### DIFF
--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -33,6 +33,10 @@ class CodeBlock extends Node
         return [
             'language' => [
                 'parseHTML' => function ($DOMNode) {
+                    if (!($DOMNode->childNodes[0] instanceof \DOMElement)) {
+                        return null;
+                    }
+
                     return preg_replace(
                         "/^" . $this->options['languageClassPrefix']. "/",
                         "",

--- a/tests/DOMParser/Nodes/CodeBlockTest.php
+++ b/tests/DOMParser/Nodes/CodeBlockTest.php
@@ -123,3 +123,24 @@ test('code block and inline code are rendered correctly', function () {
         ],
     ]);
 });
+
+test('it handles code blocks without a code tag', function () {
+    $html = '<pre>body { display: none }</pre>';
+
+    $result = (new Editor)->setContent($html)->getDocument();
+
+    expect($result)->toEqual([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'codeBlock',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'body { display: none }',
+                    ],
+                ],
+            ],
+        ],
+    ]);
+});


### PR DESCRIPTION
When parsing an HTML input using this library, that contains a `<pre>`-tag without any child element like the code tag generated by TipTap itself, the parser will generate an error, as it tries to call the `getAttribute` method on a child node, that is of type `DOMText` (or even null, if the block is empty). The error occurs, while infering the language of the code block.

This might not happen, if using the tip tap editor, but it breaks the use case of the sanitize method, as it would fail and not sanitize in this case.

This PR adds a check for the type of the respective child node.