### PR TITLE
Filter attributes more explicitly

### DIFF
--- a/src/Utils/HTML.php
+++ b/src/Utils/HTML.php
@@ -60,7 +60,7 @@ class HTML
         $attributes = [];
 
         // class="custom"
-        foreach (array_filter($attrs) as $name => $value) {
+        foreach (array_filter($attrs, fn ($attr) => $attr !== null) as $name => $value) {
             $escapedValue = htmlentities($value);
 
             $attributes[] = " {$name}=\"{$escapedValue}\"";


### PR DESCRIPTION
I have a custom node with the following code:

```php
public function renderHTML($node, $HTMLAttributes = [])
{
    return [
        'table',
        [
            'data-layout-section' => 'true',
            'border' => '0',
            'cellpadding' => '0',
            'cellspacing' => '0',
        ] + $HTMLAttributes,
        [
            'tr',
            0,
        ],
    ];
}
```

Unfortunately, `border`, `cellpadding`, `cellspacing` attributes are filtered out by `array_filter` because they are falsy.

This PR updates `array_filter` call to filter out only `null` values.