### PR TITLE
Fix merging class attributes

### DIFF
--- a/src/Utils/HTML.php
+++ b/src/Utils/HTML.php
@@ -18,7 +18,7 @@ class HTML
             foreach ($moreAttributes as $key => $value) {
                 // class="foo bar"
                 if ($key === 'class') {
-                    $attributes['class'] = trim($attributes['class'] ?? '' . ' ' . $value);
+                    $attributes['class'] = trim(($attributes['class'] ?? '') . ' ' . $value);
 
                     continue;
                 }

--- a/tests/Utils/HTMLTest.php
+++ b/tests/Utils/HTMLTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Tiptap\Utils\Html;
+
+test('classes are merged properly', function () {
+    $attributes = [
+        ['class' => 'a'],
+        ['class' => 'b'],
+    ];
+
+    $result = Html::mergeAttributes(...$attributes);
+
+    expect($result)->toEqual(['class' => 'a b']);
+});

--- a/tests/Utils/HTMLTest.php
+++ b/tests/Utils/HTMLTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Tiptap\Utils\Html;
+use Tiptap\Utils\HTML;
 
 test('classes are merged properly', function () {
     $attributes = [
@@ -8,7 +8,7 @@ test('classes are merged properly', function () {
         ['class' => 'b'],
     ];
 
-    $result = Html::mergeAttributes(...$attributes);
+    $result = HTML::mergeAttributes(...$attributes);
 
     expect($result)->toEqual(['class' => 'a b']);
 });


### PR DESCRIPTION
Currently merging class attributes doesn't work due to the way the null coalesce and concat operators are combined.

This PR fixes that, and also includes a test.