### PR TITLE
fix misaligned tags for overlapping marks

### DIFF
--- a/src/Core/DOMSerializer.php
+++ b/src/Core/DOMSerializer.php
@@ -17,9 +17,10 @@ class DOMSerializer
         $this->schema = $schema;
     }
 
-    private function renderNode($node, $previousNode = null, $nextNode = null): string
+    private function renderNode($node, $previousNode = null, $nextNode = null, &$markStack = []): string
     {
         $html = [];
+        $markTagsToClose = [];
 
         if (isset($node->marks)) {
             foreach ($node->marks as $mark) {
@@ -35,6 +36,8 @@ class DOMSerializer
                     }
 
                     $html[] = $this->renderOpeningTag($renderClass, $mark);
+                    # push recently created mark tag to the stack
+                    $markStack[] = [$renderClass, $mark];
                 }
             }
         }
@@ -57,11 +60,12 @@ class DOMSerializer
         }
         // child nodes
         elseif (isset($node->content)) {
+            $nestedNodeMarkStack = [];
             foreach ($node->content as $index => $nestedNode) {
                 $previousNestedNode = $node->content[$index - 1] ?? null;
                 $nextNestedNode = $node->content[$index + 1] ?? null;
 
-                $html[] = $this->renderNode($nestedNode, $previousNestedNode, $nextNestedNode);
+                $html[] = $this->renderNode($nestedNode, $previousNestedNode, $nextNestedNode, $nestedNodeMarkStack);
             }
         }
         // renderText($node)
@@ -92,12 +96,64 @@ class DOMSerializer
                         continue;
                     }
 
-                    $html[] = $this->renderClosingTag($extension->renderHTML($mark));
+                    # remember which mark tags to close
+                    $markTagsToClose[] = [$extension, $mark];
                 }
             }
+            # close mark tags and reopen when necessary
+            $html = array_merge($html, $this->closeAndReopenTags($markTagsToClose, $markStack));
         }
 
         return join($html);
+    }
+
+    private function closeAndReopenTags(array $markTagsToClose, array &$markStack): array
+    {
+        $markTagsToReopen = [];
+        $closingTags = $this->closeMarkTags($markTagsToClose, $markStack, $markTagsToReopen);
+        $reopeningTags = $this->reopenMarkTags($markTagsToReopen, $markStack);
+        return array_merge($closingTags, $reopeningTags);
+    }
+
+    private function closeMarkTags($markTagsToClose, &$markStack, &$markTagsToReopen): array
+    {
+        $html = [];
+        while(!empty($markTagsToClose))
+        {
+            # close mark tag from the top of the stack
+            $markTag = array_pop($markStack);
+            $markExtension = $markTag[0];
+            $mark = $markTag[1];
+            $html[] = $this->renderClosingTag($markExtension->renderHTML( $mark ));
+
+            # check if the last closed tag is overlapping and has to be reopened
+            if(count(array_filter($markTagsToClose, function($markToClose) use ($markExtension, $mark){
+                    return $markExtension == $markToClose[0] && $mark == $markToClose[1];
+                })) == 0)
+            {
+                $markTagsToReopen[] = $markTag;
+            }
+            else {
+                # mark tag does not have to be reopened, but deleted from the 'to close' list
+                $markTagsToClose = array_udiff($markTagsToClose, [$markTag], function ($a1, $a2) {
+                    return strcmp($a1[1]->type, $a2[1]->type);});
+            }
+        }
+        return $html;
+    }
+
+    private function reopenMarkTags($markTagsToReopen, &$markStack): array
+    {
+        $html = [];
+        # reopen the overlapping mark tags and push them to the stack
+        foreach(array_reverse($markTagsToReopen) as $markTagToOpen)
+        {
+            $renderClass = $markTagToOpen[0];
+            $mark = $markTagToOpen[1];
+            $html[] = $this->renderOpeningTag($renderClass, $mark);
+            $markStack[] = [$renderClass, $mark];
+        }
+        return $html;
     }
 
     private function isMarkOrNode($markOrNode, $renderClass): bool
@@ -331,11 +387,13 @@ class DOMSerializer
 
         $content = is_array($this->document->content) ? $this->document->content : [];
 
+        $markStack = [];
+
         foreach ($content as $index => $node) {
             $previousNode = $content[$index - 1] ?? null;
             $nextNode = $content[$index + 1] ?? null;
 
-            $html[] = $this->renderNode($node, $previousNode, $nextNode);
+            $html[] = $this->renderNode($node, $previousNode, $nextNode, $markStack);
         }
 
         return join($html);

--- a/src/Core/DOMSerializer.php
+++ b/src/Core/DOMSerializer.php
@@ -112,33 +112,33 @@ class DOMSerializer
         $markTagsToReopen = [];
         $closingTags = $this->closeMarkTags($markTagsToClose, $markStack, $markTagsToReopen);
         $reopeningTags = $this->reopenMarkTags($markTagsToReopen, $markStack);
+
         return array_merge($closingTags, $reopeningTags);
     }
 
     private function closeMarkTags($markTagsToClose, &$markStack, &$markTagsToReopen): array
     {
         $html = [];
-        while(!empty($markTagsToClose))
-        {
+        while(! empty($markTagsToClose)) {
             # close mark tag from the top of the stack
             $markTag = array_pop($markStack);
             $markExtension = $markTag[0];
             $mark = $markTag[1];
-            $html[] = $this->renderClosingTag($markExtension->renderHTML( $mark ));
+            $html[] = $this->renderClosingTag($markExtension->renderHTML($mark));
 
             # check if the last closed tag is overlapping and has to be reopened
-            if(count(array_filter($markTagsToClose, function($markToClose) use ($markExtension, $mark){
-                    return $markExtension == $markToClose[0] && $mark == $markToClose[1];
-                })) == 0)
-            {
+            if(count(array_filter($markTagsToClose, function ($markToClose) use ($markExtension, $mark) {
+                return $markExtension == $markToClose[0] && $mark == $markToClose[1];
+            })) == 0) {
                 $markTagsToReopen[] = $markTag;
-            }
-            else {
+            } else {
                 # mark tag does not have to be reopened, but deleted from the 'to close' list
                 $markTagsToClose = array_udiff($markTagsToClose, [$markTag], function ($a1, $a2) {
-                    return strcmp($a1[1]->type, $a2[1]->type);});
+                    return strcmp($a1[1]->type, $a2[1]->type);
+                });
             }
         }
+
         return $html;
     }
 
@@ -146,13 +146,13 @@ class DOMSerializer
     {
         $html = [];
         # reopen the overlapping mark tags and push them to the stack
-        foreach(array_reverse($markTagsToReopen) as $markTagToOpen)
-        {
+        foreach(array_reverse($markTagsToReopen) as $markTagToOpen) {
             $renderClass = $markTagToOpen[0];
             $mark = $markTagToOpen[1];
             $html[] = $this->renderOpeningTag($renderClass, $mark);
             $markStack[] = [$renderClass, $mark];
         }
+
         return $html;
     }
 

--- a/tests/DOMParser/MultipleMarksTest.php
+++ b/tests/DOMParser/MultipleMarksTest.php
@@ -4,6 +4,7 @@ use Tiptap\Editor;
 
 test('multiple marks are rendered correctly', function () {
     $html = '<p><strong><em>Example Text</em></strong></p>';
+
     $result = (new Editor)->setContent($html)->getDocument();
 
     expect($result)->toEqual([

--- a/tests/DOMParser/MultipleMarksTest.php
+++ b/tests/DOMParser/MultipleMarksTest.php
@@ -4,7 +4,6 @@ use Tiptap\Editor;
 
 test('multiple marks are rendered correctly', function () {
     $html = '<p><strong><em>Example Text</em></strong></p>';
-
     $result = (new Editor)->setContent($html)->getDocument();
 
     expect($result)->toEqual([

--- a/tests/DOMSerializer/MultipleMarksTest.php
+++ b/tests/DOMSerializer/MultipleMarksTest.php
@@ -110,39 +110,39 @@ test('multiple marks get rendered correctly, when overlapping marks exist', func
                         "type" => "text",
                         "marks" => [
                             [
-                                "type" => "bold"
-                            ]
+                                "type" => "bold",
+                            ],
                         ],
-                        "text" => "lorem "
+                        "text" => "lorem ",
                     ],
                     [
                         "type" => "text",
                         "marks" => [
                             [
-                                "type" => "bold"
+                                "type" => "bold",
                             ],
                             [
-                                "type" => "italic"
-                            ]
+                                "type" => "italic",
+                            ],
                         ],
-                        "text" => "ipsum"
+                        "text" => "ipsum",
                     ],
                     [
                         "type" => "text",
                         "marks" => [
                             [
-                                "type" => "italic"
-                            ]
+                                "type" => "italic",
+                            ],
                         ],
-                        "text" => " dolor"
+                        "text" => " dolor",
                     ],
                     [
                         "type" => "text",
-                        "text" => " sit"
+                        "text" => " sit",
                     ],
-                ]
-            ]
-        ]
+                ],
+            ],
+        ],
     ];
 
     $result = (new Editor)
@@ -164,44 +164,44 @@ test('multiple marks get rendered correctly, when overlapping passage with multi
                         "type" => "text",
                         "marks" => [
                             [
-                                "type" => "bold"
+                                "type" => "bold",
                             ],
                             [
-                                "type" => "strike"
-                            ]
+                                "type" => "strike",
+                            ],
                         ],
-                        "text" => "lorem "
+                        "text" => "lorem ",
                     ],
                     [
                         "type" => "text",
                         "marks" => [
                             [
-                                "type" => "italic"
+                                "type" => "italic",
                             ],
                             [
-                                "type" => "bold"
+                                "type" => "bold",
                             ],
                             [
-                                "type" => "strike"
-                            ]
+                                "type" => "strike",
+                            ],
                         ],
-                        "text" => "ipsum"
+                        "text" => "ipsum",
                     ],
                     [
                         "type" => "text",
                         "marks" => [
                             [
-                                "type" => "strike"
+                                "type" => "strike",
                             ],
                             [
-                                "type" => "italic"
+                                "type" => "italic",
                             ],
                         ],
-                        "text" => " dolor"
-                    ]
-                ]
-            ]
-        ]
+                        "text" => " dolor",
+                    ],
+                ],
+            ],
+        ],
     ];
 
     $result = (new Editor)

--- a/tests/DOMSerializer/MultipleMarksTest.php
+++ b/tests/DOMSerializer/MultipleMarksTest.php
@@ -29,6 +29,184 @@ test('multiple marks get rendered correctly', function () {
     ];
 
     $result = (new Editor)->setContent($document)->getHTML();
-
     expect($result)->toEqual('<p><strong><em>Example Text</em></strong></p>');
+});
+
+
+test('multiple marks get rendered correctly, with additional mark at the first node', function () {
+    $document = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'italic',
+                    ],
+                    [
+                        'type' => 'bold',
+                    ],
+                ],
+                'text' => 'lorem ',
+            ],
+            [
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'bold',
+                    ],
+                ],
+                'text' => 'ipsum',
+            ],
+        ],
+    ];
+    $result = (new Editor)->setContent($document)->getHTML();
+
+    expect($result)->toEqual('<em><strong>lorem </strong></em><strong>ipsum</strong>');
+});
+
+
+test('multiple marks get rendered correctly, with additional mark at the last node', function () {
+    $document = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'italic',
+                    ],
+                ],
+                'text' => 'lorem ',
+            ],
+            [
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'italic',
+                    ],
+                    [
+                        'type' => 'bold',
+                    ],
+                ],
+                'text' => 'ipsum',
+            ],
+        ],
+    ];
+    $result = (new Editor)->setContent($document)->getHTML();
+
+    expect($result)->toEqual('<em>lorem <strong>ipsum</strong></em>');
+});
+
+
+test('multiple marks get rendered correctly, when overlapping marks exist', function () {
+    $document = [
+        "type" => "doc",
+        "content" => [
+            [
+                "type" => "paragraph",
+                "content" => [
+                    [
+                        "type" => "text",
+                        "marks" => [
+                            [
+                                "type" => "bold"
+                            ]
+                        ],
+                        "text" => "lorem "
+                    ],
+                    [
+                        "type" => "text",
+                        "marks" => [
+                            [
+                                "type" => "bold"
+                            ],
+                            [
+                                "type" => "italic"
+                            ]
+                        ],
+                        "text" => "ipsum"
+                    ],
+                    [
+                        "type" => "text",
+                        "marks" => [
+                            [
+                                "type" => "italic"
+                            ]
+                        ],
+                        "text" => " dolor"
+                    ],
+                    [
+                        "type" => "text",
+                        "text" => " sit"
+                    ],
+                ]
+            ]
+        ]
+    ];
+
+    $result = (new Editor)
+        ->setContent($document)
+        ->getHTML();
+
+    expect($result)->toEqual('<p><strong>lorem <em>ipsum</em></strong><em> dolor</em> sit</p>');
+});
+
+
+test('multiple marks get rendered correctly, when overlapping passage with multiple marks exist', function () {
+    $document = [
+        "type" => "doc",
+        "content" => [
+            [
+                "type" => "paragraph",
+                "content" => [
+                    [
+                        "type" => "text",
+                        "marks" => [
+                            [
+                                "type" => "bold"
+                            ],
+                            [
+                                "type" => "strike"
+                            ]
+                        ],
+                        "text" => "lorem "
+                    ],
+                    [
+                        "type" => "text",
+                        "marks" => [
+                            [
+                                "type" => "italic"
+                            ],
+                            [
+                                "type" => "bold"
+                            ],
+                            [
+                                "type" => "strike"
+                            ]
+                        ],
+                        "text" => "ipsum"
+                    ],
+                    [
+                        "type" => "text",
+                        "marks" => [
+                            [
+                                "type" => "strike"
+                            ],
+                            [
+                                "type" => "italic"
+                            ],
+                        ],
+                        "text" => " dolor"
+                    ]
+                ]
+            ]
+        ]
+    ];
+
+    $result = (new Editor)
+        ->setContent($document)
+        ->getHTML();
+
+    expect($result)->toEqual('<p><strong><strike>lorem <em>ipsum</em></strike></strong><strike><em> dolor</em></strike></p>');
 });


### PR DESCRIPTION
This solves the issue with misaligned tags for overlapping marks, see https://github.com/ueberdosis/tiptap-php/issues/33

In order to preserve the correct order when closing and reopening html tags, a stack is used to track all currently open mark tags.