### PR TITLE
Remove Strict Versioning on scrivo/highlight.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "scrivo/highlight.php": "v9.18.1.9",
+        "scrivo/highlight.php": "v9.18.1.10",
         "spatie/shiki-php": "^1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "scrivo/highlight.php": "v9.18",
+        "scrivo/highlight.php": "^9.18",
         "spatie/shiki-php": "^1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "scrivo/highlight.php": "v9.18.1.10",
+        "scrivo/highlight.php": "v9.18",
         "spatie/shiki-php": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request addresses the issue mentioned in #41. 

Removing the strict version lock allow for more compatibility. And to follow the guidelines set by the authors themselves. [scrivo/highlight.php's readme.md](https://github.com/scrivo/highlight.php#composer-version-constraints).