### PR TITLE
Wrap contents of table header and table cell nodes in paragraph

### DIFF
--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -72,4 +72,18 @@ class TableCell extends Node
             0,
         ];
     }
+
+    public static function wrapper($DOMNode)
+    {
+        if (
+            $DOMNode->childNodes->length === 1
+            && $DOMNode->childNodes[0]->nodeName == "p"
+        ) {
+            return null;
+        }
+
+        return [
+            'type' => 'paragraph',
+        ];
+    }
 }

--- a/src/Nodes/TableHeader.php
+++ b/src/Nodes/TableHeader.php
@@ -35,4 +35,18 @@ class TableHeader extends TableCell
             0,
         ];
     }
+
+    public static function wrapper($DOMNode)
+    {
+        if (
+            $DOMNode->childNodes->length === 1
+            && $DOMNode->childNodes[0]->nodeName == "p"
+        ) {
+            return null;
+        }
+
+        return [
+            'type' => 'paragraph',
+        ];
+    }
 }


### PR DESCRIPTION
Importing tables from HTML causes the content of table cells to not be wrapped in paragraph tags which Tiptap js then complains is invalid content.

This takes the wrapper code from the TaskItem https://github.com/ueberdosis/tiptap-php/blob/main/src/Nodes/TaskItem.php#L71-L83 and applies it to the TableHeader and TableCell nodes as well.