### PR TITLE
Fix to deprecated function call

### DIFF
--- a/src/Utils/HTML.php
+++ b/src/Utils/HTML.php
@@ -25,7 +25,7 @@ class HTML
 
                 // style="color: red;"
                 if ($key === 'style') {
-                    $style = rtrim($attributes['style'] ?? '', '; ') . '; ' . rtrim($value, ';') . '; ';
+                    $style = rtrim($attributes['style'] ?? '', '; ') . '; ' . rtrim($value ?? '', ';') . '; ';
                     $attributes['style'] = ltrim(trim($style), '; ');
 
                     continue;


### PR DESCRIPTION
I received warnings in my logs about a deprecated function call:

```
LOG.warning: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/ueberdosis/tiptap-php/src/Utils/HTML.php on line 28
```

On this same line, I noticed there's an already existing coalesce for an `rtrim` function, for the style attribute.
I simply did the same method of coalescing the `value` variable to an empty string if it's `null`.