### PR TITLE
feature: support extension for TextSerializer

### DIFF
--- a/src/Core/DOMSerializer.php
+++ b/src/Core/DOMSerializer.php
@@ -8,6 +8,8 @@ use Tiptap\Utils\HTML;
 
 class DOMSerializer
 {
+    use SerializerTrait;
+
     protected $document;
 
     protected $schema;
@@ -154,11 +156,6 @@ class DOMSerializer
         }
 
         return $html;
-    }
-
-    private function isMarkOrNode($markOrNode, $renderClass): bool
-    {
-        return isset($markOrNode->type) && $markOrNode->type === $renderClass::$name;
     }
 
     private function markShouldOpen($mark, $previousNode): bool

--- a/src/Core/SerializerTrait.php
+++ b/src/Core/SerializerTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tiptap\Core;
+
+
+trait SerializerTrait
+{
+    private function isMarkOrNode($markOrNode, $renderClass): bool
+    {
+        return isset($markOrNode->type) && $markOrNode->type === $renderClass::$name;
+    }
+}

--- a/src/Core/TextSerializer.php
+++ b/src/Core/TextSerializer.php
@@ -4,6 +4,8 @@ namespace Tiptap\Core;
 
 class TextSerializer
 {
+    use SerializerTrait;
+
     protected $document;
 
     protected $schema;
@@ -37,6 +39,13 @@ class TextSerializer
     private function renderNode($node): string
     {
         $text = [];
+        $extension = null;
+        foreach ($this->schema->nodes as $curExtension) {
+            if ($this->isMarkOrNode($node, $curExtension)) {
+                $extension = $curExtension;
+                break;
+            }
+        }
 
         if (isset($node->content)) {
             foreach ($node->content as $nestedNode) {
@@ -44,6 +53,8 @@ class TextSerializer
             }
         } elseif (isset($node->text)) {
             $text[] = htmlspecialchars($node->text, ENT_QUOTES, 'UTF-8');
+        } elseif (isset($extension) && method_exists($extension, 'renderText')) {
+            $text[] = $extension->renderText($node);
         }
 
         return join($this->configuration['blockSeparator'], $text);

--- a/tests/DOMSerializer/Nodes/MentionTest.php
+++ b/tests/DOMSerializer/Nodes/MentionTest.php
@@ -77,3 +77,43 @@ test('label can be customized', function () {
 
     expect($output)->toEqual('<p>Hey <span data-type="mention" data-id="123">@Philipp</span>, was geht?</p>');
 });
+
+test('label can be customized and displayed for getText', function () {
+    $document = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Hey ',
+                    ],
+                    [
+                        'type' => 'mention',
+                        'attrs' => [
+                            'id' => 123,
+                        ],
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ', was geht?',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    $output = (new Editor([
+        'extensions' => [
+            new StarterKit,
+            new Mention([
+                'renderLabel' => fn ($node) => '@Philipp',
+            ]),
+        ],
+    ]))->setContent($document)->getText([
+        'blockSeparator' => "",
+    ]);
+
+    expect($output)->toEqual('Hey @Philipp, was geht?');
+});

--- a/tests/TextSerializer/InputTest.php
+++ b/tests/TextSerializer/InputTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Tiptap\Editor;
+use Tiptap\Extensions\StarterKit;
+use Tiptap\Nodes\Image;
+
+test('escaped attribute values', function () {
+    $result = (new Editor([
+        'extensions' => [
+            new StarterKit,
+            new Image,
+        ],
+    ]))->setContent([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'image',
+                'attrs' => [
+                    'src' => '"><script type="text/javascript">alert(1);</script><img src="',
+                ],
+            ],
+        ],
+    ])->getHTML();
+
+    expect($result)->toEqual('<img src="&quot;&gt;&lt;script type=&quot;text/javascript&quot;&gt;alert(1);&lt;/script&gt;&lt;img src=&quot;">');
+});


### PR DESCRIPTION
Hi, i found that i can't use extension in TextSerializer for get text while I using function
for example:
``` php
Editor([
    'extensions' => [
        new CustomNode(),
    ],
])
->setContent($content)
->getText();
```
I hope it can be supported, otherwise i can't get text from custom format.