### PR TITLE
Drop Support for Unsupported PHP Versions (BC Break)

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.0"
+          php-version: "8.3"
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.4, 8.0, 8.1]
+        php: [8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
         node-version: [16]
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.3",
         "scrivo/highlight.php": "^9.18",
         "spatie/shiki-php": "^2.0"
     },


### PR DESCRIPTION
This PR drops support for PHP `7.4` and PHP `8.0`, raising the minimum required PHP version to `^8.3`. This change introduces a backward compatibility (BC) break, as projects running on older PHP versions will no longer be compatible.

I’d love to contribute more to this project!

My suggestion would be to create a `2.x` branch where this PR could be targeted, maintaining backward compatibility for users on older PHP versions.

Additionally, I’d be excited to help with **adding strict types** to the library, ensuring even better code quality and reliability.