### PR TITLE
Change <strike> to <s> in HTML rendering and update related tests

### DIFF
--- a/src/Marks/Strike.php
+++ b/src/Marks/Strike.php
@@ -36,6 +36,6 @@ class Strike extends Mark
 
     public function renderHTML($mark, $HTMLAttributes = [])
     {
-        return ['strike', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
+        return ['s', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }
 }

--- a/tests/DOMSerializer/Marks/StrikeTest.php
+++ b/tests/DOMSerializer/Marks/StrikeTest.php
@@ -23,5 +23,5 @@ test('strike gets rendered correctly', function () {
         ->setContent($document)
         ->getHTML();
 
-    expect($result)->toEqual('<strike>Example Text</strike>');
+    expect($result)->toEqual('<s>Example Text</s>');
 });

--- a/tests/DOMSerializer/MultipleMarksTest.php
+++ b/tests/DOMSerializer/MultipleMarksTest.php
@@ -208,5 +208,5 @@ test('multiple marks get rendered correctly, when overlapping passage with multi
         ->setContent($document)
         ->getHTML();
 
-    expect($result)->toEqual('<p><strong><strike>lorem <em>ipsum</em></strike></strong><strike><em> dolor</em></strike></p>');
+    expect($result)->toEqual('<p><strong><s>lorem <em>ipsum</em></s></strong><s><em> dolor</em></s></p>');
 });


### PR DESCRIPTION
As mentioned here: https://github.com/ueberdosis/tiptap-php/issues/38 `<strike>` is deprecated (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strike).

This PR switched to from `<strike>` to `<s>`. We also already have this behavior in the editor: https://github.com/ueberdosis/tiptap/blob/f3258d9ee5fb7979102fe63434f6ea4120507311/packages/extension-strike/src/strike.ts#L82.