### PR TITLE
Add noContent property to Node

### DIFF
--- a/src/Core/DOMParser.php
+++ b/src/Core/DOMParser.php
@@ -82,7 +82,7 @@ class DOMParser
                     continue;
                 }
 
-                if ($child->hasChildNodes()) {
+                if (!$class::$noContent && $child->hasChildNodes()) {
                     $item = array_merge($item, [
                         'content' => $this->processChildren($child),
                     ]);

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -8,6 +8,8 @@ class Node extends Extension
 
     public static $topNode = false;
 
+    public static $noContent = false;
+
     public static $marks = '_';
 
     public function addAttributes()

--- a/tests/DOMParser/Nodes/BlockquoteCite.php
+++ b/tests/DOMParser/Nodes/BlockquoteCite.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tiptap\Tests\DOMParser\Nodes;
+
+use Tiptap\Core\Node;
+
+class BlockquoteCite extends Node
+{
+    public static $name = 'blockquoteCite';
+
+    public static $noContent = true;
+
+    public function addAttributes(): array
+    {
+        return [
+            'quote' => [
+                'parseHTML' => fn ($domNode) => $domNode->childNodes[0]->childNodes[0]->textContent ?? '',
+            ],
+            'author' => [
+                'parseHTML' => fn ($domNode) => $domNode->childNodes[1]->textContent ?? '',
+            ],
+        ];
+    }
+
+    public function parseHTML()
+    {
+        return [
+            [
+                'tag' => 'blockquote',
+                'getAttrs' => fn ($domNode) => isset($domNode->childNodes[1]) && $domNode->childNodes[1]->tagName === 'cite',
+            ],
+        ];
+    }
+}

--- a/tests/DOMParser/Nodes/BlockquoteCiteTest.php
+++ b/tests/DOMParser/Nodes/BlockquoteCiteTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Tiptap\Editor;
+use Tiptap\Extensions\StarterKit;
+use Tiptap\Tests\DOMParser\Nodes\BlockquoteCite;
+
+test('no content node gets rendered correctly', function () {
+    $html = '<blockquote><p>Quote</p><cite>Author</cite></blockquote>';
+
+    $result = (new Editor([
+        'extensions' => [
+            new StarterKit,
+            new BlockquoteCite,
+        ],
+    ]))->setContent($html)->getDocument();
+
+    expect($result)->toEqual([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'blockquoteCite',
+                'attrs' => [
+                    'quote' => 'Quote',
+                    'author' => 'Author',
+                ],
+            ],
+        ],
+    ]);
+});


### PR DESCRIPTION
It can be useful to specify that an extension has no content at all, for instance when parsing a HTML node containing multiple tags (I added an example for a `<blockquote>` containing a `<cite>` tag).

In JS, it can be done by not using the `content` key:
```js
export const BlockquoteCite = Node.create({
  name: 'blockquoteCite',
  group: "block",

  parseHTML() {}
```

In this PR, I propose to add a `$noContent` static property to Node to specify this behavior.
When set to `true`, the `content` key is not added to the array.