### PR TITLE
Removed wrapper logic which wrapps lists into p tags

### DIFF
--- a/src/Core/DOMParser.php
+++ b/src/Core/DOMParser.php
@@ -94,14 +94,6 @@ class DOMParser
                     ]);
                 }
 
-                if ($wrapper = $class::wrapper($child)) {
-                    $item['content'] = [
-                        array_merge($wrapper, [
-                            'content' => $item['content'] ?? [],
-                        ]),
-                    ];
-                }
-
                 array_push($nodes, $item);
             } elseif ($class = $this->getMarkFor($child)) {
                 array_push($this->storedMarks, $this->parseAttributes($class, $child));

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -25,8 +25,8 @@ class Node extends Extension
         return null;
     }
 
-    public static function wrapper($DOMNode)
-    {
-        return null;
-    }
+    // public static function wrapper($DOMNode)
+    // {
+    //     return null;
+    // }
 }

--- a/src/Core/Node.php
+++ b/src/Core/Node.php
@@ -24,9 +24,4 @@ class Node extends Extension
     {
         return null;
     }
-
-    // public static function wrapper($DOMNode)
-    // {
-    //     return null;
-    // }
 }

--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -21,9 +21,9 @@ class Link extends Mark
                 'rel' => 'noopener noreferrer nofollow',
             ],
             'allowedProtocols' => [
-                'http', 'https', 'ftp', 'ftps', 'mailto', 'tel', 'callto', 'sms', 'cid', 'xmpp'
+                'http', 'https', 'ftp', 'ftps', 'mailto', 'tel', 'callto', 'sms', 'cid', 'xmpp',
             ],
-            'isAllowedUri' => fn($uri) => $this->isAllowedUri($uri)
+            'isAllowedUri' => fn ($uri) => $this->isAllowedUri($uri),
         ];
     }
 
@@ -51,7 +51,7 @@ class Link extends Mark
 
                     if (
                         $href === '' ||
-                        !$this->options['isAllowedUri']($href)
+                        ! $this->options['isAllowedUri']($href)
                     ) {
                         return false;
                     }
@@ -76,7 +76,7 @@ class Link extends Mark
     {
         $isAllowed = $this->options['isAllowedUri']($HTMLAttributes['href'] ?? '');
 
-        if(!$isAllowed) {
+        if (! $isAllowed) {
             $HTMLAttributes['href'] = '';
         }
 

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -30,17 +30,17 @@ class ListItem extends Node
         return ['li', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }
 
-    public static function wrapper($DOMNode)
-    {
-        if (
-            $DOMNode->childNodes->length === 1
-            && $DOMNode->childNodes[0]->nodeName == "p"
-        ) {
-            return null;
-        }
+    // public static function wrapper($DOMNode)
+    // {
+    //     if (
+    //         $DOMNode->childNodes->length === 1
+    //         && $DOMNode->childNodes[0]->nodeName == "p"
+    //     ) {
+    //         return null;
+    //     }
 
-        return [
-            'type' => 'paragraph',
-        ];
-    }
+    //     return [
+    //         'type' => 'paragraph',
+    //     ];
+    // }
 }

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -29,18 +29,4 @@ class ListItem extends Node
     {
         return ['li', HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes), 0];
     }
-
-    // public static function wrapper($DOMNode)
-    // {
-    //     if (
-    //         $DOMNode->childNodes->length === 1
-    //         && $DOMNode->childNodes[0]->nodeName == "p"
-    //     ) {
-    //         return null;
-    //     }
-
-    //     return [
-    //         'type' => 'paragraph',
-    //     ];
-    // }
 }

--- a/src/Nodes/TaskItem.php
+++ b/src/Nodes/TaskItem.php
@@ -68,17 +68,17 @@ class TaskItem extends Node
         ];
     }
 
-    public static function wrapper($DOMNode)
-    {
-        if (
-            $DOMNode->childNodes->length === 1
-            && $DOMNode->childNodes[0]->nodeName == "p"
-        ) {
-            return null;
-        }
+    // public static function wrapper($DOMNode)
+    // {
+    //     if (
+    //         $DOMNode->childNodes->length === 1
+    //         && $DOMNode->childNodes[0]->nodeName == "p"
+    //     ) {
+    //         return null;
+    //     }
 
-        return [
-            'type' => 'paragraph',
-        ];
-    }
+    //     return [
+    //         'type' => 'paragraph',
+    //     ];
+    // }
 }

--- a/src/Nodes/TaskItem.php
+++ b/src/Nodes/TaskItem.php
@@ -67,18 +67,4 @@ class TaskItem extends Node
             ],
         ];
     }
-
-    // public static function wrapper($DOMNode)
-    // {
-    //     if (
-    //         $DOMNode->childNodes->length === 1
-    //         && $DOMNode->childNodes[0]->nodeName == "p"
-    //     ) {
-    //         return null;
-    //     }
-
-    //     return [
-    //         'type' => 'paragraph',
-    //     ];
-    // }
 }

--- a/tests/DOMParser/Marks/LinkTest.php
+++ b/tests/DOMParser/Marks/LinkTest.php
@@ -124,7 +124,8 @@ test('link_mark_has_support_for_target', function () {
     ]);
 });
 
-function getValidUrls() {
+function getValidUrls()
+{
     return [
         'https://example.com',
         'http://example.com',
@@ -135,7 +136,8 @@ function getValidUrls() {
     ];
 }
 
-function getInvalidUrls() {
+function getInvalidUrls()
+{
     // Copied from https://github.com/ueberdosis/tiptap/blob/next/tests/cypress/integration/extensions/link.spec.ts
 
     return [
@@ -191,8 +193,9 @@ function getInvalidUrls() {
     ];
 }
 
-function getJsonContent($url) {
-    return [ 
+function getJsonContent($url)
+{
+    return [
         'type' => 'doc',
         'content' => [
             [
@@ -216,11 +219,12 @@ function getJsonContent($url) {
     ];
 }
 
-function getHtmlContent($url) {
+function getHtmlContent($url)
+{
     return '<p><a href="' . $url . '">Click me</a></p>';
 }
 
-test('link_mark_does_output_href_tag_for_valid_JSON_schemas', function() {
+test('link_mark_does_output_href_tag_for_valid_JSON_schemas', function () {
     foreach (getValidUrls() as $url) {
         $content = getJsonContent($url);
 
@@ -237,7 +241,7 @@ test('link_mark_does_output_href_tag_for_valid_JSON_schemas', function() {
     }
 });
 
-test('link_mark_does_not_output_href_tag_for_valid_JSON_schemas', function() {
+test('link_mark_does_not_output_href_tag_for_valid_JSON_schemas', function () {
     foreach (getInvalidUrls() as $url) {
         $content = getJsonContent($url);
 
@@ -254,7 +258,7 @@ test('link_mark_does_not_output_href_tag_for_valid_JSON_schemas', function() {
     }
 });
 
-test('link_mark_does_output_href_tag_for_valid_HTML_schemas', function() {
+test('link_mark_does_output_href_tag_for_valid_HTML_schemas', function () {
     foreach (getValidUrls() as $url) {
         $content = getHtmlContent($url);
 
@@ -271,7 +275,7 @@ test('link_mark_does_output_href_tag_for_valid_HTML_schemas', function() {
     }
 });
 
-test('link_mark_does_not_output_href_tag_for_valid_HTML_schemas', function() {
+test('link_mark_does_not_output_href_tag_for_valid_HTML_schemas', function () {
     foreach (getInvalidUrls() as $url) {
         $content = getHtmlContent($url);
 

--- a/tests/DOMParser/MarksInNodesTest.php
+++ b/tests/DOMParser/MarksInNodesTest.php
@@ -151,14 +151,14 @@ test('multiple lists gets rendered correctly', function () {
     $html = '
         <h2>Headline 2</h2>
         <ol>
-            <li>ordered list item</li>
-            <li>ordered list item</li>
-            <li>ordered list item</li>
+            <li><p>ordered list item</p></li>
+            <li><p>ordered list item</p></li>
+            <li><p>ordered list item</p></li>
         </ol>
         <ul>
-            <li>unordered list item</li>
-            <li>unordered list item with <a href="https://tiptap.dev"><strong>link</strong></a></li>
-            <li>unordered list item</li>
+            <li><p>unordered list item</p></li>
+            <li><p>unordered list item with <a href="https://tiptap.dev"><strong>link</strong></a></p></li>
+            <li><p>unordered list item</p></li>
         </ul>
         <p>Some Text.</p>
     ';

--- a/tests/DOMParser/Nodes/BulletListTest.php
+++ b/tests/DOMParser/Nodes/BulletListTest.php
@@ -50,7 +50,7 @@ test('bulletList gets rendered correctly', function () {
 });
 
 test('bulletlistItem with text only gets wrapped in paragraph', function () {
-    $html = '<ul><li>Example</li><li>Text <em>Test</em></li></ul>';
+    $html = '<ul><li><p>Example</p></li><li><p>Text <em>Test</em></p></li></ul>';
 
     $result = (new Editor)
         ->setContent($html)
@@ -106,7 +106,7 @@ test('bulletlistItem with text only gets wrapped in paragraph', function () {
 });
 
 test('listItems with space get rendered correctly', function () {
-    $html = '<ul><li> </li></ul>';
+    $html = '<ul><li><p> </p></li></ul>';
 
     $result = (new Editor)
         ->setContent($html)
@@ -123,7 +123,39 @@ test('listItems with space get rendered correctly', function () {
                         'content' => [
                             [
                                 'type' => 'paragraph',
-                                'content' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+});
+
+test('listItems content get rendered correctly', function () {
+    $html = '<ul><li><p>Tiptap</p></li></ul>';
+
+    $result = (new Editor)
+        ->setContent($html)
+        ->getDocument();
+
+    expect($result)->toEqual([
+        'type' => 'doc',
+        'content' => [  
+            [
+                'type' => 'bulletList',
+                'content' => [
+                    [
+                        'type' => 'listItem',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'type' => 'text',
+                                        'text' => 'Tiptap',
+                                    ],
+                                ],
                             ],
                         ],
                     ],

--- a/tests/DOMParser/Nodes/BulletListTest.php
+++ b/tests/DOMParser/Nodes/BulletListTest.php
@@ -141,7 +141,7 @@ test('listItems content get rendered correctly', function () {
 
     expect($result)->toEqual([
         'type' => 'doc',
-        'content' => [  
+        'content' => [
             [
                 'type' => 'bulletList',
                 'content' => [


### PR DESCRIPTION
This PR remove the wrapper logic.

**Why this approach was chosen**
1. The idea to remove the wrapper function exists since some time: https://github.com/ueberdosis/tiptap-php/issues/2
2. It only handles very simple cases and is error prone to more complex and nested lists: https://github.com/ueberdosis/tiptap-php/issues/36 

The [workaround some people have taken](https://github.com/ueberdosis/tiptap-php/issues/2#issuecomment-1546706151) is to overwrite the extension and return null for the wrapper and disable this feature.

**What was the goal of the wrapper function**
If you have simple lists like 
```
<ul>
  <li>
    Some list item
  </li>
</ul>
```
ProseMirror would put that list item into p tags resulting in:
```
<ul>
  <li>
    <p>Some list item</p>
  </li>
</ul>
```
The wrapper function tried to replicate this behavior. 

**Why I think it's OK to remove it**
The tiptap-php library is just a very simple and lightweight way to work with Tiptap json. Trying to replicate the content behavior of ProseMirror comes with an enormous implementation effort. 
In the end, Tiptap knows how to handle lists where items are not wrapped in p tags and will wrap them. So everything should still work as expected.