### PR TITLE
Ensure number strings are treated as HTML

### DIFF
--- a/src/Editor.php
+++ b/src/Editor.php
@@ -89,6 +89,11 @@ class Editor
     public function getContentType($value): string
     {
         if (is_string($value)) {
+            // Ensure number strings are treated as HTML, e.g. "1999"
+            if (ctype_digit(mb_substr($value, 0, 1))) {
+                return 'HTML';
+            }
+
             try {
                 /**
                  * @psalm-suppress UnusedFunctionCall

--- a/tests/DOMParser/NumberStringTest.php
+++ b/tests/DOMParser/NumberStringTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Tiptap\Editor;
+
+test('parsing must not fail on number string', function () {
+    $html = '1999';
+
+    $result = (new Editor)
+        ->setContent($html)
+        ->getDocument();
+
+    expect($result)->toEqual([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => "1999",
+                    ],
+                ],
+            ],
+        ],
+    ]);
+});


### PR DESCRIPTION
- A pure number string like `1999` will currently be interpreted as valid JSON
- This will fail in subsequent steps because a JSON object/array is expected, instead of the number `1999`
- This change will mark any string starting with a number as HTML going forward
- An alternative could be to expect `{` or `[` as first character to mark things as JSON
- I've added a test, but can't get it to run locally because of PHP deprecations in Pest :(