### PR TITLE
Fix: Handle duplicate mark instances correctly in DOMSerializer

### DIFF
--- a/src/Core/DOMSerializer.php
+++ b/src/Core/DOMSerializer.php
@@ -127,15 +127,21 @@ class DOMSerializer
             $html[] = $this->renderClosingTag($markExtension->renderHTML($mark));
 
             # check if the last closed tag is overlapping and has to be reopened
-            if (count(array_filter($markTagsToClose, function ($markToClose) use ($markExtension, $mark) {
-                return $markExtension == $markToClose[0] && $mark == $markToClose[1];
-            })) == 0) {
+            # find the first matching mark to close
+            $foundIndex = null;
+            foreach ($markTagsToClose as $index => $markToClose) {
+                if ($markExtension == $markToClose[0] && $mark == $markToClose[1]) {
+                    $foundIndex = $index;
+                    break;
+                }
+            }
+
+            if ($foundIndex === null) {
                 $markTagsToReopen[] = $markTag;
             } else {
-                # mark tag does not have to be reopened, but deleted from the 'to close' list
-                $markTagsToClose = array_udiff($markTagsToClose, [$markTag], function ($a1, $a2) {
-                    return strcmp($a1[1]->type, $a2[1]->type);
-                });
+                # specific mark tag does not have to be reopened, but deleted from the 'to close' list
+                unset($markTagsToClose[$foundIndex]);
+                $markTagsToClose = array_values($markTagsToClose); // Re-index array
             }
         }
 

--- a/tests/DOMSerializer/MultipleMarksTest.php
+++ b/tests/DOMSerializer/MultipleMarksTest.php
@@ -3,6 +3,8 @@
 namespace Tiptap\Tests\HTMLOutput\Mix;
 
 use Tiptap\Editor;
+use Tiptap\Extensions\StarterKit;
+use Tiptap\Marks\TextStyle;
 
 test('multiple marks get rendered correctly', function () {
     $document = [
@@ -209,4 +211,47 @@ test('multiple marks get rendered correctly, when overlapping passage with multi
         ->getHTML();
 
     expect($result)->toEqual('<p><strong><s>lorem <em>ipsum</em></s></strong><s><em> dolor</em></s></p>');
+});
+
+test('renders duplicate mark types as nested elements', function () {
+    $document = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Example',
+                        'marks' => [
+                            [
+                                'type' => 'bold',
+                            ],
+                            [
+                                'type' => 'textStyle',
+                            ],
+                            [
+                                'type' => 'textStyle',
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' Text',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    $result = (new Editor([
+        'extensions' => [
+            new StarterKit,
+            new TextStyle,
+        ],
+    ]))
+        ->setContent($document)
+        ->getHTML();
+
+    expect($result)->toEqual('<p><strong><span><span>Example</span></span></strong> Text</p>');
 });


### PR DESCRIPTION
Fixes a bug where duplicate mark types (e.g., multiple `textStyle` marks on the same node) were incorrectly handled, causing marks to stay open.

  **Example:**
  ```php
 $document = [
        'type' => 'doc',
        'content' => [
            [
                'type' => 'paragraph',
                'content' => [
                    [
                        'type' => 'text',
                        'text' => 'Example',
                        'marks' => [
                            [
                                'type' => 'bold',
                            ],
                            [
                                'type' => 'textStyle',
                            ],
                            [
                                'type' => 'textStyle', // duplicate
                            ],
                        ],
                    ],
                    [
                        'type' => 'text',
                        'text' => ' Text',
                    ],
                ],
            ],
        ],
    ];
```

**Before:**
```html
<p><strong><span><span>Example</span></span></strong><span> Text</p>
```

**After:**
```html
<p><strong><span><span>Example</span></span></strong> Text</p>
```