### PR TITLE
Add contentElement support to Node

### DIFF
--- a/src/Core/DOMParser.php
+++ b/src/Core/DOMParser.php
@@ -84,7 +84,7 @@ class DOMParser
 
                 if ($child->hasChildNodes()) {
                     $item = array_merge($item, [
-                        'content' => $this->processChildren($child),
+                        'content' => $this->processChildren(isset($item['contentDom']) ? $item['contentDom'] : $child),
                     ]);
                 }
 
@@ -93,6 +93,8 @@ class DOMParser
                         'marks' => $this->storedMarks,
                     ]);
                 }
+
+                unset($item['contentDom']);
 
                 array_push($nodes, $item);
             } elseif ($class = $this->getMarkFor($child)) {
@@ -283,7 +285,7 @@ class DOMParser
     /**
      * @return (array|mixed|string)[]|null
      *
-     * @psalm-return array{type: mixed, text?: string, attrs?: array}|null
+     * @psalm-return array{type: mixed, text?: string, attrs?: array, contentDom?: mixed}|null
      */
     private function parseAttributes($class, $DOMNode): ?array
     {
@@ -312,6 +314,16 @@ class DOMParser
         foreach ($parseRules as $parseRule) {
             if (! $this->checkParseRule($parseRule, $DOMNode)) {
                 continue;
+            }
+
+            if (isset($parseRule['contentElement'])) {
+                if (is_string($parseRule['contentElement'])) {
+                    throw new \Exception("Tiptap for PHP does not support CSS selector in contentElement yet");
+                } else if (is_callable($parseRule['contentElement'])) {
+                    $item['contentDom'] = $parseRule['contentElement']($DOMNode);
+                } else {
+                    $item['contentDom'] = $parseRule['contentElement'];
+                }
             }
 
             $attributes = $parseRule['attrs'] ?? [];

--- a/tests/DOMParser/Nodes/ContentElement.php
+++ b/tests/DOMParser/Nodes/ContentElement.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tiptap\Tests\DOMParser\Nodes;
+
+use Tiptap\Core\Node;
+
+class ContentElement extends Node
+{
+    public static $name = 'contentElement';
+
+    public function parseHTML()
+    {
+        return [
+            [
+                'tag' => 'div',
+                'contentElement' => fn ($domNode) => new \DOMElement('div', $domNode->lastChild->textContent),
+                'getAttrs' => fn ($domNode) => $domNode->getAttribute('class') === 'contentElement',
+            ],
+        ];
+    }
+}

--- a/tests/DOMParser/Nodes/ContentElementTest.php
+++ b/tests/DOMParser/Nodes/ContentElementTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Tiptap\Editor;
+use Tiptap\Extensions\StarterKit;
+use Tiptap\Tests\DOMParser\Nodes\ContentElement;
+
+test('node with contentElement gets rendered correctly', function () {
+    $html = '<div class="contentElement"><span>no content</span><span>content</span></div>';
+
+    $result = (new Editor([
+        'extensions' => [
+            new StarterKit,
+            new ContentElement,
+        ],
+    ]))->setContent($html)->getDocument();
+
+    expect($result)->toEqual([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'contentElement',
+                'content' => [
+                    ['type' => 'text', 'text' => 'content'],
+                ],
+            ],
+        ],
+    ]);
+});


### PR DESCRIPTION
Add the possibility to use `contentElement` for a `Node` : https://prosemirror.net/docs/ref/#model.TagParseRule.contentElement

I tried to change as little code as possible.