### PR TITLE
Use configurable theme for Shiki highlighting

### DIFF
--- a/src/Nodes/CodeBlockShiki.php
+++ b/src/Nodes/CodeBlockShiki.php
@@ -46,7 +46,7 @@ class CodeBlockShiki extends CodeBlock
         }
 
         try {
-            $content = Shiki::highlight($code, $language, 'nord');
+            $content = Shiki::highlight($code, $language, $this->options['theme']);
         } catch (DomainException $exception) {
             $mergedAttributes = HTML::mergeAttributes(
                 $this->options['HTMLAttributes'],


### PR DESCRIPTION
Replaces the hardcoded 'nord' theme with a dynamic theme from options when highlighting code blocks with Shiki. This allows users to specify their preferred theme.