### PR TITLE
Fix: Prevent TypeError when link href is not a string

### DIFF
--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -33,6 +33,10 @@ class Link extends Mark
             return true;
         }
 
+        if (! is_string($uri)) {
+            return false;
+        }
+
         $sanitised = preg_replace(self::ATTR_WHITESPACE, '', $uri);
 
         $pattern = '/^(?:(?:' . implode('|', array_map('preg_quote', $this->options['allowedProtocols']))

--- a/tests/DOMSerializer/Marks/LinkTest.php
+++ b/tests/DOMSerializer/Marks/LinkTest.php
@@ -247,6 +247,36 @@ test('link mark can disable rel', function () {
     expect($result)->toEqual('<a target="_blank" href="https://tiptap.dev">Example Link</a>');
 });
 
+test('link mark with non-string (array) href does not crash and is treated as disallowed', function () {
+    $document = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'text',
+                'text' => 'Example',
+                'marks' => [
+                    [
+                        'type' => 'link',
+                        'attrs' => [
+                            'href' => ['array', 'value'],
+                            'target' => '_blank',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    $result = (new Editor([
+        'extensions' => [
+            new StarterKit,
+            new Link,
+        ],
+    ]))->setContent($document)->getHTML();
+
+    expect($result)->toEqual('<a target="_blank" rel="noopener noreferrer nofollow">Example</a>');
+});
+
 test('link mark can disable target', function () {
     $document = [
         'type' => 'doc',


### PR DESCRIPTION
`isAllowedUri() `passed the href straight to preg_replace/preg_match, which throw a TypeError on non-string values (e.g. an array from crafted Tiptap JSON), crashing getHTML(). Guard for non-string input and treat it as a disallowed URI.