### PR TITLE
Add PHP and JavaScript compatibility test workflow

### DIFF
--- a/.github/workflows/js-compatibility.yml
+++ b/.github/workflows/js-compatibility.yml
@@ -1,0 +1,50 @@
+name: JS compatibility
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      tiptap-version:
+        description: Tiptap npm version or dist-tag
+        required: false
+        default: latest
+        type: string
+
+jobs:
+  compatibility:
+    name: compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: dom, libxml, mbstring
+          coverage: none
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install PHP dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Install JavaScript dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Run compatibility tests
+        run: composer test-compatibility
+        env:
+          TIPTAP_VERSION: ${{ inputs.tiptap-version || 'latest' }}

--- a/README.md
+++ b/README.md
@@ -370,6 +370,30 @@ You can install nodemon (`npm install -g nodemon`) to keep the test suite runnin
 composer test-watch
 ```
 
+### JavaScript compatibility
+
+The compatibility suite verifies that the PHP and JavaScript packages parse the same HTML into equivalent Tiptap JSON. It also checks both cross-runtime rendering directions: HTML rendered by PHP must be parseable by JavaScript, and HTML rendered by JavaScript must be parseable by PHP.
+
+By default, the suite installs and tests the latest Tiptap JavaScript release:
+
+```bash
+npm ci
+composer test-compatibility
+```
+
+Pass an npm version or dist-tag to test a specific Tiptap release:
+
+```bash
+composer test-compatibility -- 3.27.3
+composer test-compatibility -- next
+```
+
+The version can also be provided through the `TIPTAP_VERSION` environment variable:
+
+```bash
+TIPTAP_VERSION=3.27.3 composer test-compatibility
+```
+
 ## Contributing
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "psalm": "vendor/bin/psalm",
         "psalm-watch": "nodemon --exec './vendor/bin/psalm || exit 1' --ext php",
         "test": "./vendor/bin/pest",
+        "test-compatibility": "@php tests/Compatibility/run.php",
         "test-watch": "nodemon --exec './vendor/bin/pest || exit 1' --ext php",
         "test-coverage": "./vendor/bin/pest --coverage-html coverage",
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes --config=.php_cs.dist.php"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "description": "This package.json has all Node dependencies for the local development of the package.",
   "homepage": "https://github.com/ueberdosis/tiptap-php",
+  "scripts": {
+    "install-compatibility-dependencies": "node tests/Compatibility/js/install-dependencies.mjs"
+  },
   "devDependencies": {
     "shiki": "^2.0.0"
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
     <testsuites>
         <testsuite name="VendorName Test Suite">
             <directory>tests</directory>
+            <exclude>tests/Compatibility</exclude>
         </testsuite>
     </testsuites>
     <coverage>

--- a/tests/Compatibility/CompatibilityTest.php
+++ b/tests/Compatibility/CompatibilityTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use Tiptap\Editor;
+use Tiptap\Extensions\Color;
+use Tiptap\Extensions\FontFamily;
+use Tiptap\Extensions\StarterKit;
+use Tiptap\Extensions\TextAlign;
+use Tiptap\Marks\Highlight;
+use Tiptap\Marks\Link;
+use Tiptap\Marks\Subscript;
+use Tiptap\Marks\Superscript;
+use Tiptap\Marks\TextStyle;
+use Tiptap\Marks\Underline;
+use Tiptap\Nodes\Details;
+use Tiptap\Nodes\DetailsContent;
+use Tiptap\Nodes\DetailsSummary;
+use Tiptap\Nodes\Image;
+use Tiptap\Nodes\Mention;
+use Tiptap\Nodes\Table;
+use Tiptap\Nodes\TableCell;
+use Tiptap\Nodes\TableHeader;
+use Tiptap\Nodes\TableRow;
+use Tiptap\Nodes\TaskItem;
+use Tiptap\Nodes\TaskList;
+
+function compatibilityExtensions(string $profile): array
+{
+    $starterKit = new StarterKit;
+
+    return match ($profile) {
+        'starterKit' => [$starterKit],
+        'marks' => [
+            $starterKit,
+            new Link,
+            new Underline,
+            new Highlight(['multicolor' => true]),
+            new Subscript,
+            new Superscript,
+        ],
+        'styles' => [
+            $starterKit,
+            new TextStyle,
+            new Color,
+            new FontFamily,
+            new TextAlign(['types' => ['heading', 'paragraph']]),
+        ],
+        'image' => [$starterKit, new Image],
+        'mention' => [$starterKit, new Mention],
+        'taskList' => [$starterKit, new TaskList, new TaskItem],
+        'table' => [$starterKit, new Table, new TableRow, new TableHeader, new TableCell],
+        'details' => [
+            $starterKit,
+            new Details(['persist' => true]),
+            new DetailsSummary,
+            new DetailsContent,
+        ],
+        default => throw new InvalidArgumentException("Unknown extension profile: {$profile}"),
+    };
+}
+
+function compatibilityEditor(string $profile): Editor
+{
+    return new Editor(['extensions' => compatibilityExtensions($profile)]);
+}
+
+function callTiptapJs(string $operation, string $profile, $value)
+{
+    $command = ['node', __DIR__ . '/js/bridge.mjs'];
+    $pipes = [];
+    $process = proc_open($command, [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ], $pipes, dirname(__DIR__, 2));
+
+    if (! is_resource($process)) {
+        throw new RuntimeException('Unable to start the Tiptap JS bridge.');
+    }
+
+    fwrite($pipes[0], json_encode([
+        'operation' => $operation,
+        'profile' => $profile,
+        'value' => $value,
+    ], JSON_THROW_ON_ERROR));
+    fclose($pipes[0]);
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $exitCode = proc_close($process);
+
+    if ($exitCode !== 0) {
+        throw new RuntimeException("Tiptap JS bridge failed:\n{$stderr}");
+    }
+
+    return json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+}
+
+function canonicalCompatibilityDocument(array $value): array
+{
+    if (array_is_list($value)) {
+        return array_map(
+            fn ($item) => is_array($item) ? canonicalCompatibilityDocument($item) : $item,
+            $value,
+        );
+    }
+
+    foreach ($value as $key => $item) {
+        if (is_array($item)) {
+            $value[$key] = canonicalCompatibilityDocument($item);
+        }
+    }
+
+    if (isset($value['attrs']) && is_array($value['attrs'])) {
+        $value['attrs'] = array_filter($value['attrs'], fn ($attribute) => $attribute !== null);
+        $type = $value['type'] ?? null;
+
+        if ($type === 'orderedList' && ($value['attrs']['start'] ?? null) === 1) {
+            unset($value['attrs']['start']);
+        }
+        if ($type === 'taskItem' && ($value['attrs']['checked'] ?? null) === false) {
+            unset($value['attrs']['checked']);
+        }
+        if (in_array($type, ['tableCell', 'tableHeader'], true)) {
+            foreach (['colspan', 'rowspan'] as $attribute) {
+                if (($value['attrs'][$attribute] ?? null) === 1) {
+                    unset($value['attrs'][$attribute]);
+                }
+            }
+        }
+        if ($type === 'mention' && ($value['attrs']['mentionSuggestionChar'] ?? null) === '@') {
+            unset($value['attrs']['mentionSuggestionChar']);
+        }
+        if ($value['attrs'] === []) {
+            unset($value['attrs']);
+        }
+    }
+
+    ksort($value);
+
+    return $value;
+}
+
+dataset('compatibility fixtures', function () {
+    foreach (glob(__DIR__ . '/fixtures/*.json') as $path) {
+        $fixture = json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        yield $fixture['name'] => [$fixture];
+    }
+});
+
+test('PHP and JS parse HTML to the same document', function (array $fixture) {
+    $expected = canonicalCompatibilityDocument($fixture['document']);
+    $phpDocument = compatibilityEditor($fixture['profile'])
+        ->setContent($fixture['html'])
+        ->getDocument();
+    $jsDocument = callTiptapJs('parse', $fixture['profile'], $fixture['html']);
+
+    expect(canonicalCompatibilityDocument($phpDocument))->toEqual($expected)
+        ->and(canonicalCompatibilityDocument($jsDocument))->toEqual($expected);
+})->with('compatibility fixtures');
+
+test('PHP-rendered HTML can be parsed by JS', function (array $fixture) {
+    $expected = canonicalCompatibilityDocument($fixture['document']);
+    $html = compatibilityEditor($fixture['profile'])
+        ->setContent($fixture['document'])
+        ->getHTML();
+
+    expect(canonicalCompatibilityDocument(callTiptapJs('parse', $fixture['profile'], $html)))
+        ->toEqual($expected);
+})->with('compatibility fixtures');
+
+test('JS-rendered HTML can be parsed by PHP', function (array $fixture) {
+    $expected = canonicalCompatibilityDocument($fixture['document']);
+    $html = callTiptapJs('render', $fixture['profile'], $fixture['document']);
+    $document = compatibilityEditor($fixture['profile'])
+        ->setContent($html)
+        ->getDocument();
+
+    expect(canonicalCompatibilityDocument($document))->toEqual($expected);
+})->with('compatibility fixtures');

--- a/tests/Compatibility/fixtures/details.json
+++ b/tests/Compatibility/fixtures/details.json
@@ -1,0 +1,16 @@
+{
+  "name": "persisted details state",
+  "profile": "details",
+  "html": "<details open><summary>Summary</summary><div data-type=\"detailsContent\"><p>Content</p></div></details>",
+  "document": {
+    "type": "doc",
+    "content": [{
+      "type": "details",
+      "attrs": { "open": true },
+      "content": [
+        { "type": "detailsSummary", "content": [{ "type": "text", "text": "Summary" }] },
+        { "type": "detailsContent", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Content" }] }] }
+      ]
+    }]
+  }
+}

--- a/tests/Compatibility/fixtures/image.json
+++ b/tests/Compatibility/fixtures/image.json
@@ -1,0 +1,18 @@
+{
+  "name": "image attributes",
+  "profile": "image",
+  "html": "<img src=\"https://tiptap.dev/logo.png\" alt=\"Tiptap\" title=\"Logo\" width=\"320\" height=\"180\">",
+  "document": {
+    "type": "doc",
+    "content": [{
+      "type": "image",
+      "attrs": {
+        "src": "https://tiptap.dev/logo.png",
+        "alt": "Tiptap",
+        "title": "Logo",
+        "width": "320",
+        "height": "180"
+      }
+    }]
+  }
+}

--- a/tests/Compatibility/fixtures/marks.json
+++ b/tests/Compatibility/fixtures/marks.json
@@ -1,0 +1,22 @@
+{
+  "name": "additional marks",
+  "profile": "marks",
+  "html": "<p><a href=\"https://tiptap.dev\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">link</a> <u>underline</u> <mark data-color=\"yellow\" style=\"background-color: yellow\">highlight</mark> H<sub>2</sub>O x<sup>2</sup></p>",
+  "document": {
+    "type": "doc",
+    "content": [{
+      "type": "paragraph",
+      "content": [
+        { "type": "text", "marks": [{ "type": "link", "attrs": { "href": "https://tiptap.dev", "target": "_blank", "rel": "noopener noreferrer nofollow" } }], "text": "link" },
+        { "type": "text", "text": " " },
+        { "type": "text", "marks": [{ "type": "underline" }], "text": "underline" },
+        { "type": "text", "text": " " },
+        { "type": "text", "marks": [{ "type": "highlight", "attrs": { "color": "yellow" } }], "text": "highlight" },
+        { "type": "text", "text": " H" },
+        { "type": "text", "marks": [{ "type": "subscript" }], "text": "2" },
+        { "type": "text", "text": "O x" },
+        { "type": "text", "marks": [{ "type": "superscript" }], "text": "2" }
+      ]
+    }]
+  }
+}

--- a/tests/Compatibility/fixtures/mention.json
+++ b/tests/Compatibility/fixtures/mention.json
@@ -1,0 +1,16 @@
+{
+  "name": "mention id",
+  "profile": "mention",
+  "html": "<p>Hello <span data-type=\"mention\" data-id=\"123\"></span>!</p>",
+  "document": {
+    "type": "doc",
+    "content": [{
+      "type": "paragraph",
+      "content": [
+        { "type": "text", "text": "Hello " },
+        { "type": "mention", "attrs": { "id": "123" } },
+        { "type": "text", "text": "!" }
+      ]
+    }]
+  }
+}

--- a/tests/Compatibility/fixtures/starter-kit.json
+++ b/tests/Compatibility/fixtures/starter-kit.json
@@ -1,0 +1,26 @@
+{
+  "name": "starter kit nodes and marks",
+  "profile": "starterKit",
+  "html": "<h2>Heading</h2><blockquote><p>Quote</p></blockquote><p>Plain <strong>bold <em>and italic</em></strong><br>next</p><ul><li><p>Bullet</p></li></ul><ol start=\"3\"><li><p>Third</p></li></ol><pre><code class=\"language-css\">body { color: red; }</code></pre><hr>",
+  "document": {
+    "type": "doc",
+    "content": [
+      { "type": "heading", "attrs": { "level": 2 }, "content": [{ "type": "text", "text": "Heading" }] },
+      { "type": "blockquote", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Quote" }] }] },
+      {
+        "type": "paragraph",
+        "content": [
+          { "type": "text", "text": "Plain " },
+          { "type": "text", "marks": [{ "type": "bold" }], "text": "bold " },
+          { "type": "text", "marks": [{ "type": "bold" }, { "type": "italic" }], "text": "and italic" },
+          { "type": "hardBreak" },
+          { "type": "text", "text": "next" }
+        ]
+      },
+      { "type": "bulletList", "content": [{ "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Bullet" }] }] }] },
+      { "type": "orderedList", "attrs": { "start": 3 }, "content": [{ "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Third" }] }] }] },
+      { "type": "codeBlock", "attrs": { "language": "css" }, "content": [{ "type": "text", "text": "body { color: red; }" }] },
+      { "type": "horizontalRule" }
+    ]
+  }
+}

--- a/tests/Compatibility/fixtures/styles.json
+++ b/tests/Compatibility/fixtures/styles.json
@@ -1,0 +1,17 @@
+{
+  "name": "text styles and alignment",
+  "profile": "styles",
+  "html": "<p style=\"text-align: center\"><span style=\"color: red; font-family: Arial\">Styled</span></p>",
+  "document": {
+    "type": "doc",
+    "content": [{
+      "type": "paragraph",
+      "attrs": { "textAlign": "center" },
+      "content": [{
+        "type": "text",
+        "marks": [{ "type": "textStyle", "attrs": { "color": "red", "fontFamily": "Arial" } }],
+        "text": "Styled"
+      }]
+    }]
+  }
+}

--- a/tests/Compatibility/js/bridge.mjs
+++ b/tests/Compatibility/js/bridge.mjs
@@ -1,0 +1,83 @@
+import { Details, DetailsContent, DetailsSummary } from '@tiptap/extension-details'
+import Highlight from '@tiptap/extension-highlight'
+import Image from '@tiptap/extension-image'
+import { TaskItem, TaskList } from '@tiptap/extension-list'
+import Mention from '@tiptap/extension-mention'
+import Subscript from '@tiptap/extension-subscript'
+import Superscript from '@tiptap/extension-superscript'
+import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
+import TextAlign from '@tiptap/extension-text-align'
+import { Color, FontFamily, TextStyle } from '@tiptap/extension-text-style'
+import { generateHTML, generateJSON } from '@tiptap/html/server'
+import StarterKit from '@tiptap/starter-kit'
+import { readFileSync } from 'node:fs'
+
+const starterKit = (options = {}) => StarterKit.configure({
+  dropcursor: false,
+  gapcursor: false,
+  link: false,
+  listKeymap: false,
+  trailingNode: false,
+  underline: false,
+  undoRedo: false,
+  ...options,
+})
+
+const profiles = {
+  starterKit: () => [starterKit()],
+  marks: () => [
+    starterKit({ link: {}, underline: {} }),
+    Highlight.configure({ multicolor: true }),
+    Subscript,
+    Superscript,
+  ],
+  styles: () => [
+    starterKit(),
+    TextStyle,
+    Color,
+    FontFamily,
+    TextAlign.configure({ types: ['heading', 'paragraph'] }),
+  ],
+  image: () => [starterKit(), Image],
+  mention: () => [
+    starterKit(),
+    Mention.configure({
+      renderHTML: ({ node }) => [
+        'span',
+        {
+          'data-id': node.attrs.id,
+          'data-type': 'mention',
+        },
+      ],
+    }),
+  ],
+  taskList: () => [starterKit(), TaskList, TaskItem],
+  table: () => [starterKit(), Table, TableRow, TableHeader, TableCell],
+  details: () => [
+    starterKit(),
+    Details.configure({ persist: true }),
+    DetailsSummary,
+    DetailsContent,
+  ],
+}
+
+try {
+  const request = JSON.parse(readFileSync(0, 'utf8'))
+  const createExtensions = profiles[request.profile]
+
+  if (!createExtensions) {
+    throw new Error(`Unknown extension profile: ${request.profile}`)
+  }
+
+  const extensions = createExtensions()
+  const result = request.operation === 'parse'
+    ? generateJSON(request.value, extensions)
+    : request.operation === 'render'
+      ? generateHTML(request.value, extensions)
+      : (() => { throw new Error(`Unknown operation: ${request.operation}`) })()
+
+  process.stdout.write(JSON.stringify(result))
+} catch (error) {
+  process.stderr.write(`${error.stack ?? error.message}\n`)
+  process.exitCode = 1
+}

--- a/tests/Compatibility/js/install-dependencies.mjs
+++ b/tests/Compatibility/js/install-dependencies.mjs
@@ -1,0 +1,48 @@
+import { spawnSync } from 'node:child_process'
+
+const packages = [
+  '@tiptap/extension-details',
+  '@tiptap/extension-highlight',
+  '@tiptap/extension-image',
+  '@tiptap/extension-list',
+  '@tiptap/extension-mention',
+  '@tiptap/extension-subscript',
+  '@tiptap/extension-superscript',
+  '@tiptap/extension-table',
+  '@tiptap/extension-text-align',
+  '@tiptap/extension-text-style',
+  '@tiptap/html',
+  '@tiptap/starter-kit',
+]
+
+const requestedVersion = process.env.TIPTAP_VERSION || 'latest'
+const view = spawnSync(
+  'npm',
+  ['view', `@tiptap/html@${requestedVersion}`, 'version'],
+  { encoding: 'utf8' },
+)
+
+if (view.status !== 0) {
+  process.stderr.write(view.stderr)
+  process.exit(view.status ?? 1)
+}
+
+const resolvedVersion = view.stdout.trim()
+
+process.stdout.write(`Installing Tiptap JS ${resolvedVersion}\n`)
+
+const install = spawnSync(
+  'npm',
+  [
+    'install',
+    '--no-save',
+    '--package-lock=false',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    ...packages.map(packageName => `${packageName}@${resolvedVersion}`),
+  ],
+  { stdio: 'inherit' },
+)
+
+process.exit(install.status ?? 1)

--- a/tests/Compatibility/run.php
+++ b/tests/Compatibility/run.php
@@ -1,0 +1,28 @@
+<?php
+
+$version = $argv[1] ?? (getenv('TIPTAP_VERSION') ?: 'latest');
+
+putenv("TIPTAP_VERSION={$version}");
+
+$run = function (array $command): void {
+    $process = proc_open(
+        $command,
+        [STDIN, STDOUT, STDERR],
+        $pipes,
+        dirname(__DIR__, 2),
+    );
+
+    if (! is_resource($process)) {
+        fwrite(STDERR, 'Unable to start: ' . implode(' ', $command) . PHP_EOL);
+        exit(1);
+    }
+
+    $exitCode = proc_close($process);
+
+    if ($exitCode !== 0) {
+        exit($exitCode);
+    }
+};
+
+$run(['npm', 'run', 'install-compatibility-dependencies']);
+$run([PHP_BINARY, 'vendor/bin/pest', 'tests/Compatibility']);


### PR DESCRIPTION

  ## Summary

  Add an end-to-end compatibility suite for the PHP and JavaScript Tiptap packages.

  The suite verifies that:

  - PHP and JavaScript parse the same HTML into equivalent Tiptap JSON.
  - HTML rendered by PHP can be parsed by JavaScript.
  - HTML rendered by JavaScript can be parsed by PHP.

  Fixtures cover the shared StarterKit functionality, additional marks, text styles, images, mentions, and details.

  ## CI

  A separate GitHub Actions workflow:

  - Tests against the latest Tiptap JavaScript release by default.
  - Supports selecting an npm version or dist-tag through `workflow_dispatch`.
  - Installs all Tiptap packages at the same resolved version.
  - Runs independently from the regular PHP test suite.

  ## Local usage

  Test against the latest JavaScript release:

  ```bash
  npm ci
  composer test-compatibility
```
  Test a specific version or dist-tag:
```bash
composer test-compatibility -- 3.27.3
composer test-compatibility -- next
```
  The `TIPTAP_VERSION` environment variable is also supported:

  `TIPTAP_VERSION=3.27.3 composer test-compatibility`